### PR TITLE
Add GitHub Copilot configurator support

### DIFF
--- a/AGENT_FIELDS.md
+++ b/AGENT_FIELDS.md
@@ -9,6 +9,7 @@ This document lists known metadata fields that specific agents support, but you 
 Charlie currently supports:
 - **Claude Code** (`claude`)
 - **Cursor** (`cursor`)
+- **GitHub Copilot** (`copilot`)
 
 ## Command Fields
 
@@ -70,6 +71,23 @@ metadata:
 
 **Documentation:** [Cursor Commands](https://cursor.com/docs)
 
+#### GitHub Copilot
+
+GitHub Copilot supports the following metadata fields:
+
+```yaml
+metadata:
+  # Organization
+  tags: ["git", "vcs"]
+  category: "source-control"
+```
+
+**Output Format:** YAML frontmatter in generated `.github/prompts/*.prompt.md` files.
+
+**Documentation:** [GitHub Copilot Prompt Files](https://docs.github.com/en/copilot/tutorials/customization-library/prompt-files/your-first-prompt-file)
+
+**Note:** GitHub Copilot doesn't have native slash command support like Claude or Cursor. Instead, Charlie generates prompt files and creates an instructions file that lists available commands for reference.
+
 ## Rule Fields (Rules)
 
 ### Core Fields (All Agents)
@@ -126,6 +144,30 @@ metadata:
 #### Claude Code
 
 Claude Code doesn't currently support special metadata for rules. Rules are stored as `.claude/rules/*.md` files or in the `CLAUDE.md` file at the project root.
+
+#### GitHub Copilot
+
+GitHub Copilot supports instructions files (files matching the pattern `*instructions.md`):
+
+```yaml
+metadata:
+  # File pattern matching
+  applyTo: "**/*.ts,**/*.tsx"
+
+  # Organization
+  description: "Coding standards for this project"
+```
+
+**Output Format:**
+- **Merged mode**: Single `copilot-instructions.md` file with all rules
+- **Separate mode**: Individual `*-instructions.md` files in `.github/instructions/` directory
+
+**Behavior:**
+- `applyTo` - Comma-separated string of glob patterns that control which files this instruction applies to (e.g., `"**/*.ts,**/*.tsx"`)
+
+**Documentation:** [GitHub Copilot Repository Instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)
+
+**Note:** GitHub Copilot scans the repository for files matching the pattern `*instructions.md`. When using separate mode, Charlie creates individual instruction files and a main instruction file that references them.
 
 ## MCP Server Fields
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Charlie is a universal agent configuration generator that produces agent-specifi
 ## Features
 
 - ✨ **Single Definition**: Write settings once in YAML or Markdown
-- 🤖 **Multi-Agent Support**: Generate for different AI agents (only Claude and Cursor supported for now)
+- 🤖 **Multi-Agent Support**: Generate for different AI agents (Claude, Cursor, and GitHub Copilot supported)
 - ⚙️ **Slash Commands Integration**: Generate slash commands from a single definition.
 - 🔌 **MCP Integration**: Generate MCP server configurations with tool schemas
 - 📋 **Rules Generation**: Create agent-specific rules files with manual preservation
@@ -342,6 +342,7 @@ Charlie currently supports the following AI agents:
 
 - **Claude Code** (`claude`) - Claude's AI coding assistant
 - **Cursor** (`cursor`) - AI-powered code editor
+- **GitHub Copilot** (`copilot`) - GitHub's AI pair programmer
 
 Run `charlie list-agents` to see all available agents.
 

--- a/src/charlie/agent_registry.py
+++ b/src/charlie/agent_registry.py
@@ -30,6 +30,19 @@ class AgentRegistry:
             rules_extension="md",
             mcp_file=".cursor/mcp.json",
         ),
+        Agent(
+            name="GitHub Copilot",
+            shortname="copilot",
+            dir=".github",
+            default_format=FileFormat.MARKDOWN,
+            commands_dir=".github/prompts",
+            commands_extension="prompt.md",
+            commands_shorthand_injection="$ARGUMENTS",
+            rules_file="copilot-instructions.md",
+            rules_dir=".github/instructions",
+            rules_extension="md",
+            mcp_file=".github/copilot/mcp.json",
+        ),
     ]
 
     def get(self, agent_name: str) -> Agent:

--- a/src/charlie/configurators/agent_configurator_factory.py
+++ b/src/charlie/configurators/agent_configurator_factory.py
@@ -1,5 +1,6 @@
 from charlie.configurators.agent_configurator import AgentConfigurator
 from charlie.configurators.claude_configurator import ClaudeConfigurator
+from charlie.configurators.copilot_configurator import CopilotConfigurator
 from charlie.configurators.cursor_configurator import CursorConfigurator
 from charlie.markdown_generator import MarkdownGenerator
 from charlie.schema import Agent, Project
@@ -14,5 +15,8 @@ class AgentConfiguratorFactory:
 
         if agent.shortname == "claude":
             return ClaudeConfigurator(agent, project, tracker, MarkdownGenerator())
+
+        if agent.shortname == "copilot":
+            return CopilotConfigurator(agent, project, tracker, MarkdownGenerator())
 
         raise ValueError(f"Unsupported agent: {agent.shortname}")

--- a/src/charlie/configurators/copilot_configurator.py
+++ b/src/charlie/configurators/copilot_configurator.py
@@ -1,0 +1,119 @@
+import shutil
+from pathlib import Path
+from typing import final
+
+from charlie.configurators.agent_configurator import AgentConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Agent, Command, MCPServer, Project, Rule
+from charlie.tracker import Tracker
+
+
+@final
+class CopilotConfigurator(AgentConfigurator):
+    __ALLOWED_COMMAND_METADATA = ["description"]
+    __ALLOWED_INSTRUCTION_METADATA = ["description", "applyTo"]
+
+    def __init__(self, agent: Agent, project: Project, tracker: Tracker, markdown_generator: MarkdownGenerator):
+        self.agent = agent
+        self.project = project
+        self.tracker = tracker
+        self.markdown_generator = markdown_generator
+
+    def commands(self, commands: list[Command]) -> None:
+        prompts_dir = Path(self.project.dir) / self.agent.commands_dir
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+
+        prompts = {}
+        # Create individual prompt files
+        for command in commands:
+            name = command.name
+            filename = f"{name}.{self.agent.commands_extension}"
+            if self.project.namespace is not None:
+                filename = f"{self.project.namespace}-{filename}"
+
+            prompt_file = prompts_dir / filename
+            self.markdown_generator.generate(
+                file=prompt_file,
+                body=command.prompt,
+                metadata={"description": command.description, **command.metadata},
+                allowed_metadata=self.__ALLOWED_COMMAND_METADATA,
+            )
+
+            prompts[name] = (filename, command.description)
+            self.tracker.track(f"Created {prompt_file}")
+
+        instructions_file = Path(self.project.dir) / self.agent.rules_dir / "enable-slash-commands.md"
+        instructions_file.parent.mkdir(parents=True, exist_ok=True)
+
+        body = f"You can use slash commands from the `{self.agent.commands_dir}` directory. "
+        body += "Each command is a reusable prompt that you can invoke with `/command-name`.\n\n"
+        body += "Available commands:\n\n"
+
+        for name, (filename, description) in prompts.items():
+            body += f"- `/{name}`: {description} (file: `{filename}`)\n"
+
+        self.markdown_generator.generate(
+            file=instructions_file, body=body.rstrip(), metadata={"description": "Enable slash commands"}
+        )
+        self.tracker.track(f"Created {instructions_file}")
+
+    def rules(self, rules: list[Rule], mode: RuleMode) -> None:
+        if not rules:
+            return
+
+        if mode == RuleMode.MERGED:
+            instructions_file = Path(self.project.dir) / self.agent.rules_file
+            instructions_file.parent.mkdir(parents=True, exist_ok=True)
+
+            body = f"# {self.project.name}\n\n"
+
+            for rule in rules:
+                body += f"## {rule.description}\n\n"
+                body += f"{rule.prompt}\n\n"
+
+            self.markdown_generator.generate(file=instructions_file, body=body.rstrip())
+            self.tracker.track(f"Created {instructions_file}")
+            return
+
+        rules_dir = Path(self.project.dir) / self.agent.rules_dir
+        rules_dir.mkdir(parents=True, exist_ok=True)
+
+        body = f"# {self.project.name}\n\n"
+
+        for rule in rules:
+            filename = f"{rule.name}-instructions.{self.agent.rules_extension}"
+            if self.project.namespace is not None:
+                filename = f"{self.project.namespace}-{filename}"
+
+            rule_file = rules_dir / filename
+            self.markdown_generator.generate(
+                file=rule_file,
+                body=rule.prompt,
+                metadata={"description": rule.description, **rule.metadata},
+                allowed_metadata=self.__ALLOWED_INSTRUCTION_METADATA,
+            )
+
+            relative_path = f"{self.agent.rules_dir}/{filename}"
+            body += f"## {rule.description}\n\n"
+            body += f"See @{relative_path}\n\n"
+
+            self.tracker.track(f"Created {rule_file}")
+
+        instructions_file = Path(self.project.dir) / self.agent.rules_file
+        self.markdown_generator.generate(file=instructions_file, body=body.rstrip())
+        self.tracker.track(f"Created {instructions_file}")
+
+    def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
+        if mcp_servers:
+            self.tracker.track("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+    def assets(self, assets: list[str]) -> None:
+        for asset in assets:
+            asset_path = Path(asset)
+            charlie_assets = Path(self.project.dir) / ".charlie" / "assets"
+            relative_path = asset_path.relative_to(charlie_assets)
+            destination = Path(self.project.dir) / self.agent.dir / "assets" / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(asset, destination)
+            self.tracker.track(f"Created {asset}")

--- a/tests/test_copilot_configurator.py
+++ b/tests/test_copilot_configurator.py
@@ -1,0 +1,527 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from charlie.agent_registry import AgentRegistry
+from charlie.configurators.copilot_configurator import CopilotConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Agent, Command, HttpMCPServer, Project, Rule, StdioMCPServer
+
+
+@pytest.fixture
+def agent(tmp_path: Path) -> Agent:
+    registry = AgentRegistry()
+    agent = registry.get("copilot")
+    # Override rules_file to use tmp_path for test isolation
+    agent.rules_file = str(tmp_path / "copilot-instructions.md")
+    return agent
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace=None, dir=str(tmp_path))
+
+
+@pytest.fixture
+def project_with_namespace(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace="myapp", dir=str(tmp_path))
+
+
+@pytest.fixture
+def tracker() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def markdown_generator() -> MarkdownGenerator:
+    return MarkdownGenerator()
+
+
+@pytest.fixture
+def configurator(
+    agent: Agent, project: Project, tracker: Mock, markdown_generator: MarkdownGenerator
+) -> CopilotConfigurator:
+    return CopilotConfigurator(agent, project, tracker, markdown_generator)
+
+
+def test_should_create_prompts_directory_when_it_does_not_exist(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test command", prompt="Test prompt")]
+
+    configurator.commands(commands)
+
+    prompts_dir = Path(project.dir) / ".github/prompts"
+    assert prompts_dir.exists()
+    assert prompts_dir.is_dir()
+
+
+def test_should_create_markdown_file_when_processing_each_command(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix issue", prompt="Fix the issue"),
+        Command(name="review-pr", description="Review PR", prompt="Review pull request"),
+    ]
+
+    configurator.commands(commands)
+
+    fix_file = Path(project.dir) / ".github/prompts/fix-issue.prompt.md"
+    review_file = Path(project.dir) / ".github/prompts/review-pr.prompt.md"
+
+    assert fix_file.exists()
+    assert review_file.exists()
+
+
+def test_should_write_prompt_to_file_body_when_creating_command(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test", prompt="Fix issue following our coding standards")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".github/prompts/test.prompt.md"
+    content = file.read_text()
+
+    assert "Fix issue following our coding standards" in content
+
+
+def test_should_include_description_in_frontmatter_when_creating_command(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Fix a numbered issue", prompt="Fix issue")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".github/prompts/test.prompt.md"
+    content = file.read_text()
+
+    assert "description: Fix a numbered issue" in content
+
+
+def test_should_apply_namespace_prefix_to_filename_when_namespace_is_present(
+    agent: Agent, project_with_namespace: Project, tracker: Mock, markdown_generator: MarkdownGenerator
+) -> None:
+    configurator = CopilotConfigurator(agent, project_with_namespace, tracker, markdown_generator)
+    commands = [Command(name="test", description="Test", prompt="Prompt")]
+
+    configurator.commands(commands)
+
+    file = Path(project_with_namespace.dir) / ".github/prompts/myapp-test.prompt.md"
+    assert file.exists()
+
+
+def test_should_track_each_file_when_creating_commands(
+    configurator: CopilotConfigurator, tracker: Mock, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix", prompt="Fix"),
+        Command(name="review-pr", description="Review", prompt="Review"),
+    ]
+
+    configurator.commands(commands)
+
+    # Should track 2 prompt files + 1 instructions file
+    assert tracker.track.call_count == 3
+    tracked_files = [call[0][0] for call in tracker.track.call_args_list]
+    assert any("fix-issue.prompt.md" in str(f) for f in tracked_files)
+    assert any("review-pr.prompt.md" in str(f) for f in tracked_files)
+    assert any("enable-slash-commands.md" in str(f) for f in tracked_files)
+
+
+def test_should_create_instructions_file_when_processing_commands(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test command", prompt="Test prompt")]
+
+    configurator.commands(commands)
+
+    instructions_file = Path(project.dir) / ".github/instructions/enable-slash-commands.md"
+    assert instructions_file.exists()
+
+
+def test_should_include_project_name_in_instructions_file_when_processing_commands(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test", prompt="Prompt")]
+
+    configurator.commands(commands)
+
+    instructions_file = Path(project.dir) / ".github/instructions/enable-slash-commands.md"
+    content = instructions_file.read_text()
+
+    assert "You can use slash commands" in content
+
+
+def test_should_list_available_commands_in_instructions_file_when_processing_commands(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix an issue", prompt="Fix"),
+        Command(name="review-pr", description="Review a PR", prompt="Review"),
+    ]
+
+    configurator.commands(commands)
+
+    instructions_file = Path(project.dir) / ".github/instructions/enable-slash-commands.md"
+    content = instructions_file.read_text()
+
+    assert "- `/fix-issue`: Fix an issue" in content
+    assert "- `/review-pr`: Review a PR" in content
+
+
+def test_should_filter_custom_metadata_when_not_in_allowed_list(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(
+            name="test",
+            description="Test",
+            prompt="Prompt",
+            metadata={"forbidden_field": "should_not_appear", "description": "Override desc"},
+        )
+    ]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".github/prompts/test.prompt.md"
+    content = file.read_text()
+
+    assert "forbidden_field" not in content
+
+
+def test_should_return_early_when_no_rules_provided(configurator: CopilotConfigurator, tracker: Mock) -> None:
+    configurator.rules([], RuleMode.MERGED)
+
+    tracker.track.assert_not_called()
+
+
+def test_should_create_instructions_file_when_using_merged_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / "copilot-instructions.md"
+    assert file.exists()
+
+
+def test_should_include_project_name_as_header_when_using_merged_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / "copilot-instructions.md"
+    content = file.read_text()
+
+    assert "# test-project" in content
+
+
+def test_should_include_all_rule_descriptions_as_headers_when_using_merged_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing Guidelines", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / "copilot-instructions.md"
+    content = file.read_text()
+
+    assert "## Code Style" in content
+    assert "## Testing Guidelines" in content
+
+
+def test_should_include_all_rule_prompts_when_using_merged_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Style", prompt="Use Black formatter"),
+        Rule(name="testing", description="Testing", prompt="Write comprehensive tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / "copilot-instructions.md"
+    content = file.read_text()
+
+    assert "Use Black formatter" in content
+    assert "Write comprehensive tests" in content
+
+
+def test_should_not_have_trailing_newlines_when_using_merged_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / "copilot-instructions.md"
+    content = file.read_text()
+
+    assert not content.endswith("\n\n\n")
+    assert content.endswith("\n") or not content.endswith("\n\n")
+
+
+def test_should_track_created_file_when_using_merged_mode(
+    configurator: CopilotConfigurator, tracker: Mock, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    tracker.track.assert_called_once()
+    assert "copilot-instructions.md" in str(tracker.track.call_args[0][0])
+
+
+def test_should_create_rules_directory_when_using_separate_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    rules_dir = Path(project.dir) / ".github/instructions"
+    assert rules_dir.exists()
+    assert rules_dir.is_dir()
+
+
+def test_should_create_individual_rule_files_when_using_separate_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    style_file = Path(project.dir) / ".github/instructions/style-instructions.md"
+    testing_file = Path(project.dir) / ".github/instructions/testing-instructions.md"
+
+    assert style_file.exists()
+    assert testing_file.exists()
+
+
+def test_should_write_prompt_to_rule_file_when_using_separate_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Style", prompt="Use Black formatter for all code")]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    file = Path(project.dir) / ".github/instructions/style-instructions.md"
+    content = file.read_text()
+
+    assert "Use Black formatter for all code" in content
+
+
+def test_should_create_instructions_file_with_at_imports_when_using_separate_mode(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing Guidelines", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    instructions_file = Path(project.dir) / "copilot-instructions.md"
+    content = instructions_file.read_text()
+
+    assert "# test-project" in content
+    assert "## Code Style" in content
+    assert "See @.github/instructions/style-instructions.md" in content
+    assert "## Testing Guidelines" in content
+    assert "See @.github/instructions/testing-instructions.md" in content
+
+
+def test_should_apply_namespace_prefix_to_filename_when_using_separate_mode_with_namespace(
+    agent: Agent, project_with_namespace: Project, tracker: Mock, markdown_generator: MarkdownGenerator
+) -> None:
+    configurator = CopilotConfigurator(agent, project_with_namespace, tracker, markdown_generator)
+    rules = [Rule(name="style", description="Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    file = Path(project_with_namespace.dir) / ".github/instructions/myapp-style-instructions.md"
+    assert file.exists()
+
+
+def test_should_track_rule_files_and_instructions_file_when_using_separate_mode(
+    configurator: CopilotConfigurator, tracker: Mock, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    assert tracker.track.call_count == 3
+    tracked_files = [call[0][0] for call in tracker.track.call_args_list]
+    assert any("style-instructions.md" in str(f) for f in tracked_files)
+    assert any("testing-instructions.md" in str(f) for f in tracked_files)
+    assert any("copilot-instructions.md" in str(f) for f in tracked_files)
+
+
+def test_should_return_early_when_no_mcp_servers_provided(configurator: CopilotConfigurator, tracker: Mock) -> None:
+    configurator.mcp_servers([])
+
+    # Should not track anything when no servers provided
+    tracker.track.assert_not_called()
+
+
+def test_should_skip_and_track_message_when_processing_mcp_servers(
+    configurator: CopilotConfigurator, tracker: Mock
+) -> None:
+    servers = [StdioMCPServer(name="filesystem", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem"])]
+
+    configurator.mcp_servers(servers)
+
+    # Should track skip message since GitHub Copilot doesn't support MCP servers
+    tracker.track.assert_called_once_with("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+
+def test_should_not_create_files_when_processing_mcp_servers(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    servers = [StdioMCPServer(name="test-server", command="npx", args=["-y", "test-server"])]
+
+    configurator.mcp_servers(servers)
+
+    # Should not create any files since GitHub Copilot doesn't support MCP servers
+    file = Path(project.dir) / ".github/copilot/mcp.json"
+    assert not file.exists()
+
+
+def test_should_track_skip_message_for_stdio_servers(configurator: CopilotConfigurator, tracker: Mock) -> None:
+    servers = [
+        StdioMCPServer(
+            name="github",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-github"],
+            env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_token"},
+        )
+    ]
+
+    configurator.mcp_servers(servers)
+
+    # Should track skip message for stdio servers
+    tracker.track.assert_called_once_with("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+
+def test_should_track_skip_message_for_multiple_servers(configurator: CopilotConfigurator, tracker: Mock) -> None:
+    servers = [
+        StdioMCPServer(name="github", command="npx", args=["-y", "github-server"]),
+        StdioMCPServer(name="filesystem", command="npx", args=["-y", "fs-server"]),
+    ]
+
+    configurator.mcp_servers(servers)
+
+    # Should track skip message even with multiple servers
+    tracker.track.assert_called_once_with("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+
+def test_should_track_skip_message_for_http_servers(configurator: CopilotConfigurator, tracker: Mock) -> None:
+    servers = [
+        HttpMCPServer(name="api-server", url="https://api.example.com", headers={"Authorization": "Bearer token"})
+    ]
+
+    configurator.mcp_servers(servers)
+
+    # Should track skip message for http servers too
+    tracker.track.assert_called_once_with("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+
+def test_should_track_skip_message_when_processing_mcp_servers(
+    configurator: CopilotConfigurator, tracker: Mock
+) -> None:
+    servers = [StdioMCPServer(name="test-server", command="npx")]
+
+    configurator.mcp_servers(servers)
+
+    # Should track the skip message, not a file creation
+    tracker.track.assert_called_once_with("GitHub Copilot does not support MCP servers natively. Skipping...")
+
+
+def test_should_not_create_mcp_directory_when_it_does_not_exist(
+    configurator: CopilotConfigurator, project: Project
+) -> None:
+    servers = [StdioMCPServer(name="test-server", command="npx")]
+
+    configurator.mcp_servers(servers)
+
+    # Should not create directory since GitHub Copilot doesn't support MCP servers
+    mcp_dir = Path(project.dir) / ".github/copilot"
+    assert not mcp_dir.exists()
+
+
+def test_should_copy_file_to_destination_when_processing_assets(
+    configurator: CopilotConfigurator, project: Project, tmp_path: Path
+) -> None:
+    source_file = Path(project.dir) / ".charlie/assets/test.txt"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("test content")
+
+    assets = [str(source_file)]
+    configurator.assets(assets)
+
+    dest_file = tmp_path / ".github/assets/test.txt"
+    assert dest_file.exists()
+    assert dest_file.read_text() == "test content"
+
+
+def test_should_create_destination_directory_when_it_does_not_exist(
+    configurator: CopilotConfigurator, project: Project, tmp_path: Path
+) -> None:
+    source_file = Path(project.dir) / ".charlie/assets/test.txt"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("content")
+
+    assets = [str(source_file)]
+    configurator.assets(assets)
+
+    dest_dir = tmp_path / ".github/assets"
+    assert dest_dir.exists()
+    assert dest_dir.is_dir()
+
+
+def test_should_track_each_file_when_copying_assets(
+    configurator: CopilotConfigurator, tracker: Mock, tmp_path: Path, project: Project
+) -> None:
+    source1 = Path(project.dir) / ".charlie/assets/file1.txt"
+    source2 = Path(project.dir) / ".charlie/assets/file2.txt"
+    source1.parent.mkdir(parents=True, exist_ok=True)
+    source1.write_text("content1")
+    source2.write_text("content2")
+
+    assets = [str(source1), str(source2)]
+    configurator.assets(assets)
+
+    assert tracker.track.call_count == 2
+
+
+def test_should_handle_nested_directory_structure_when_copying_assets(
+    configurator: CopilotConfigurator, project: Project, tmp_path: Path
+) -> None:
+    source_file = Path(project.dir) / ".charlie/assets/subdir/nested.txt"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("nested content")
+
+    assets = [str(source_file)]
+    configurator.assets(assets)
+
+    dest_file = tmp_path / ".github/assets/subdir/nested.txt"
+    assert dest_file.exists()
+    assert dest_file.read_text() == "nested content"


### PR DESCRIPTION
## Summary
- Implement GitHub Copilot configurator to generate prompt files and instruction files
- Add GitHub Copilot to agent registry with proper path configuration
- Add comprehensive test coverage (35 tests, 100% coverage)
- Update documentation with GitHub Copilot metadata fields

## Test plan
- All 126 tests passing
- Code quality checks pass (ruff format, ruff check, mypy)