### PR TITLE
Add directory-based skill support with companion file copying

### DIFF
--- a/examples/directory-based/.charlie/skills/create-skill/SKILL.md
+++ b/examples/directory-based/.charlie/skills/create-skill/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: Guides users through creating effective Agent Skills for Cursor.
+disable-model-invocation: true
+---
+
+Use when the user wants to create, write, or author a new skill, or asks about skill structure, best practices, or SKILL.md format.
+
+## Steps
+
+1. Read the template at `{{skills_dir}}/create-skill/template.md`
+2. Ask the user for the skill name, description, and instructions
+3. Generate a new SKILL.md following the template structure
+4. Save the skill to `.charlie/skills/<skill-name>/SKILL.md`

--- a/examples/directory-based/.charlie/skills/create-skill/template.md
+++ b/examples/directory-based/.charlie/skills/create-skill/template.md
@@ -1,0 +1,5 @@
+---
+description: <What the skill does and when to use it>
+---
+
+<Skill instructions go here>

--- a/examples/directory-based/.cursor/commands/dir.deploy.md
+++ b/examples/directory-based/.cursor/commands/dir.deploy.md
@@ -16,4 +16,4 @@ Before deploying:
 
 ## Execute Deployment
 
-Run: {{assets_dir}}/deploy.ps1
+Run: {{assets_dir}}/deploy.sh

--- a/examples/directory-based/.cursor/commands/dir.init.md
+++ b/examples/directory-based/.cursor/commands/dir.init.md
@@ -13,4 +13,4 @@ Initialize a new feature based on the user's description.
 
 1. Create necessary directory structure
 2. Generate boilerplate files
-3. Run: {{assets_dir}}/init.ps1
+3. Run: {{assets_dir}}/init.sh

--- a/examples/directory-based/.cursor/skills/dir.create-skill/SKILL.md
+++ b/examples/directory-based/.cursor/skills/dir.create-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+disable-model-invocation: true
+name: dir.create-skill
+description: Guides users through creating effective Agent Skills for Cursor.
+---
+
+Use when the user wants to create, write, or author a new skill, or asks about skill structure, best practices, or SKILL.md format.
+
+## Steps
+
+1. Read the template at `.cursor/skills/create-skill/template.md`
+2. Ask the user for the skill name, description, and instructions
+3. Generate a new SKILL.md following the template structure
+4. Save the skill to `.charlie/skills/<skill-name>/SKILL.md`

--- a/examples/directory-based/.cursor/skills/dir.create-skill/template.md
+++ b/examples/directory-based/.cursor/skills/dir.create-skill/template.md
@@ -1,0 +1,5 @@
+---
+description: <What the skill does and when to use it>
+---
+
+<Skill instructions go here>

--- a/examples/simple/.claude/rules/commit-message-standards.md
+++ b/examples/simple/.claude/rules/commit-message-standards.md
@@ -2,4 +2,4 @@
 description: Commit message standards
 ---
 
-Use the en_US.UTF-8 language in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+Use the C.UTF-8 language in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

--- a/examples/simple/.claude/skills/review-pr/SKILL.md
+++ b/examples/simple/.claude/skills/review-pr/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: review-pr
-description: Review a pull request for quality, correctness, and best practices
 disable-model-invocation: true
 allowed-tools: Bash(gh pr *)
+name: review-pr
+description: Review a pull request for quality, correctness, and best practices
 ---
 
 Review the pull request $ARGUMENTS:

--- a/examples/simple/.cursor/rules/commit-message-standards.mdc
+++ b/examples/simple/.cursor/rules/commit-message-standards.mdc
@@ -2,4 +2,4 @@
 description: Commit message standards
 ---
 
-Use the en_US.UTF-8 language in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+Use the C.UTF-8 language in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

--- a/examples/simple/.cursor/skills/review-pr/SKILL.md
+++ b/examples/simple/.cursor/skills/review-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
+disable-model-invocation: true
 name: review-pr
 description: Review a pull request for quality, correctness, and best practices
-disable-model-invocation: true
 ---
 
 Review the pull request $ARGUMENTS:

--- a/src/charlie/config_reader.py
+++ b/src/charlie/config_reader.py
@@ -308,7 +308,10 @@ def parse_single_file(file_path: Path, model_class: type[T]) -> T:
         elif model_class.__name__ == "Skill":
             name = parsed_frontmatter.get("name")
             if name is None:
-                name = slugify(file_path.stem)
+                if file_path.name == "SKILL.md":
+                    name = slugify(file_path.parent.name)
+                else:
+                    name = slugify(file_path.stem)
 
             known_fields = {"name", "description", "prompt", "metadata", "replacements"}
             metadata = {k: v for k, v in parsed_frontmatter.items() if k not in known_fields}
@@ -383,6 +386,11 @@ def discover_charlie_files(base_dir: Path) -> dict[str, list[Path]]:
     skills_directory = charlie_config_directory / "skills"
     if skills_directory.exists():
         discovered_files["skills"] = sorted(skills_directory.glob("*.md"))
+        for skill_dir in sorted(skills_directory.iterdir()):
+            if skill_dir.is_dir():
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    discovered_files["skills"].append(skill_md)
 
     mcp_servers_directory = charlie_config_directory / "mcp-servers"
     if mcp_servers_directory.exists():
@@ -480,7 +488,15 @@ def load_directory_config(base_dir: Path, _visited: set[str] | None = None) -> C
     for skill_file_path in discovered_config_files["skills"]:
         try:
             parsed_skill = parse_single_file(skill_file_path, Skill)
-            merged_config_data["skills"].append(parsed_skill.model_dump())
+            skill_data = parsed_skill.model_dump()
+            if skill_file_path.name == "SKILL.md":
+                skill_source_dir = skill_file_path.parent
+                extra_files = {}
+                for extra in sorted(skill_source_dir.rglob("*")):
+                    if extra.is_file() and extra != skill_file_path:
+                        extra_files[extra.relative_to(skill_source_dir).as_posix()] = str(extra)
+                skill_data["files"] = extra_files
+            merged_config_data["skills"].append(skill_data)
         except ConfigParseError as e:
             raise ConfigParseError(f"Error loading skill from {skill_file_path}: {e}")
 

--- a/src/charlie/configurators/claude_configurator.py
+++ b/src/charlie/configurators/claude_configurator.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from pathlib import Path
 from typing import Any, final
 
@@ -195,6 +196,12 @@ class ClaudeConfigurator(AgentConfigurator):
             )
 
             self.tracker.track(f"Created {skill_file}")
+
+            for relative_path, source_path in skill.files.items():
+                dest = skill_dir / relative_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, dest)
+                self.tracker.track(f"Created {dest}")
 
     def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
         if not mcp_servers:

--- a/src/charlie/configurators/cursor_configurator.py
+++ b/src/charlie/configurators/cursor_configurator.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from typing import final
 
@@ -165,6 +166,12 @@ class CursorConfigurator(AgentConfigurator):
             )
 
             self.tracker.track(f"Created {skill_file}")
+
+            for relative_path, source_path in skill.files.items():
+                dest = skill_dir / relative_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, dest)
+                self.tracker.track(f"Created {dest}")
 
     def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
         file = Path(self.project.dir) / self.MCP_FILE

--- a/src/charlie/placeholder_transformer.py
+++ b/src/charlie/placeholder_transformer.py
@@ -102,6 +102,7 @@ class PlaceholderTransformer:
             prompt=prompt,
             metadata=metadata,
             replacements=skill.replacements,
+            files=skill.files,
         )
 
     def mcp_server(self, mcp_server: MCPServer) -> MCPServer:

--- a/src/charlie/schema.py
+++ b/src/charlie/schema.py
@@ -83,6 +83,9 @@ class Skill(BaseModel):
     prompt: str = Field(default="", description="Skill instructions")
     metadata: Metadata = Field(default_factory=dict, description="Agent-specific metadata")
     replacements: dict[str, ReplacementSpec] = Field(default_factory=dict, description="String replacements")
+    files: dict[str, str] = Field(
+        default_factory=dict, description="Map of relative destination path to source file path"
+    )
 
 
 class CharlieConfig(BaseModel):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -260,6 +260,97 @@ def test_claude_should_track_created_skill_files(
     assert "SKILL.md" in call_arg
 
 
+def test_claude_should_copy_extra_files_alongside_skill(
+    claude_configurator: ClaudeConfigurator, project: Project, tmp_path: Path
+) -> None:
+    extra_file = tmp_path / "helper.sh"
+    extra_file.write_text("#!/bin/bash\necho hello")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"helper.sh": str(extra_file)},
+        )
+    ]
+
+    claude_configurator.skills(skills)
+
+    dest = Path(project.dir) / ".claude/skills/deploy/helper.sh"
+    assert dest.exists()
+    assert dest.read_text() == "#!/bin/bash\necho hello"
+
+
+def test_claude_should_copy_nested_extra_files(
+    claude_configurator: ClaudeConfigurator, project: Project, tmp_path: Path
+) -> None:
+    nested = tmp_path / "templates"
+    nested.mkdir()
+    config_file = nested / "config.yaml"
+    config_file.write_text("key: value")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"templates/config.yaml": str(config_file)},
+        )
+    ]
+
+    claude_configurator.skills(skills)
+
+    dest = Path(project.dir) / ".claude/skills/deploy/templates/config.yaml"
+    assert dest.exists()
+    assert dest.read_text() == "key: value"
+
+
+def test_claude_should_track_extra_files(
+    claude_configurator: ClaudeConfigurator, tracker: Mock, project: Project, tmp_path: Path
+) -> None:
+    extra_file = tmp_path / "helper.sh"
+    extra_file.write_text("#!/bin/bash")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"helper.sh": str(extra_file)},
+        )
+    ]
+
+    claude_configurator.skills(skills)
+
+    assert tracker.track.call_count == 2
+    tracked_messages = [call[0][0] for call in tracker.track.call_args_list]
+    assert any("SKILL.md" in msg for msg in tracked_messages)
+    assert any("helper.sh" in msg for msg in tracked_messages)
+
+
+def test_claude_should_copy_extra_files_with_namespace(
+    claude_configurator_with_namespace: ClaudeConfigurator, project_with_namespace: Project, tmp_path: Path
+) -> None:
+    extra_file = tmp_path / "script.py"
+    extra_file.write_text("print('hello')")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"script.py": str(extra_file)},
+        )
+    ]
+
+    claude_configurator_with_namespace.skills(skills)
+
+    dest = Path(project_with_namespace.dir) / ".claude/skills/myapp-deploy/script.py"
+    assert dest.exists()
+    assert dest.read_text() == "print('hello')"
+
+
 # ─── Cursor configurator skills ──────────────────────────────────────────────
 
 
@@ -372,6 +463,74 @@ def test_cursor_should_include_namespaced_name_in_skill_frontmatter(
     assert "name: myapp.explain-code" in content
 
 
+def test_cursor_should_copy_extra_files_alongside_skill(
+    cursor_configurator: CursorConfigurator, project: Project, tmp_path: Path
+) -> None:
+    extra_file = tmp_path / "helper.sh"
+    extra_file.write_text("#!/bin/bash\necho hello")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"helper.sh": str(extra_file)},
+        )
+    ]
+
+    cursor_configurator.skills(skills)
+
+    dest = Path(project.dir) / ".cursor/skills/deploy/helper.sh"
+    assert dest.exists()
+    assert dest.read_text() == "#!/bin/bash\necho hello"
+
+
+def test_cursor_should_copy_nested_extra_files(
+    cursor_configurator: CursorConfigurator, project: Project, tmp_path: Path
+) -> None:
+    nested = tmp_path / "templates"
+    nested.mkdir()
+    config_file = nested / "config.yaml"
+    config_file.write_text("key: value")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"templates/config.yaml": str(config_file)},
+        )
+    ]
+
+    cursor_configurator.skills(skills)
+
+    dest = Path(project.dir) / ".cursor/skills/deploy/templates/config.yaml"
+    assert dest.exists()
+    assert dest.read_text() == "key: value"
+
+
+def test_cursor_should_copy_extra_files_with_namespace(
+    cursor_configurator_with_namespace: CursorConfigurator, project_with_namespace: Project, tmp_path: Path
+) -> None:
+    extra_file = tmp_path / "script.py"
+    extra_file.write_text("print('hello')")
+
+    skills = [
+        Skill(
+            name="deploy",
+            description="Deploys the app",
+            prompt="Deploy it",
+            files={"script.py": str(extra_file)},
+        )
+    ]
+
+    cursor_configurator_with_namespace.skills(skills)
+
+    dest = Path(project_with_namespace.dir) / ".cursor/skills/myapp.deploy/script.py"
+    assert dest.exists()
+    assert dest.read_text() == "print('hello')"
+
+
 # ─── Copilot configurator skills ─────────────────────────────────────────────
 
 
@@ -420,6 +579,54 @@ def test_discover_charlie_files_should_discover_skill_files(
     assert "fix-bug.md" in skill_names
 
 
+def test_discover_charlie_files_should_discover_directory_based_skills(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".charlie" / "skills" / "deploy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+    (skill_dir / "deploy.sh").write_text("#!/bin/bash\necho deploy")
+
+    discovered = discover_charlie_files(tmp_path)
+
+    skill_paths = [f for f in discovered["skills"]]
+    assert any(f.name == "SKILL.md" and f.parent.name == "deploy" for f in skill_paths)
+
+
+def test_discover_charlie_files_should_discover_both_flat_and_directory_skills(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".charlie" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "explain-code.md").write_text("---\ndescription: Explains code\n---\nExplain the code")
+
+    deploy_dir = skills_dir / "deploy"
+    deploy_dir.mkdir()
+    (deploy_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+
+    discovered = discover_charlie_files(tmp_path)
+
+    assert len(discovered["skills"]) == 2
+    names = [f.name for f in discovered["skills"]]
+    assert "explain-code.md" in names
+    assert "SKILL.md" in names
+
+
+def test_discover_charlie_files_should_ignore_directories_without_skill_md(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".charlie" / "skills"
+    skills_dir.mkdir(parents=True)
+
+    empty_dir = skills_dir / "not-a-skill"
+    empty_dir.mkdir()
+    (empty_dir / "random.txt").write_text("not a skill")
+
+    discovered = discover_charlie_files(tmp_path)
+
+    assert len(discovered["skills"]) == 0
+
+
 def test_parse_single_file_should_parse_skill_from_markdown(
     tmp_path: Path,
 ) -> None:
@@ -442,6 +649,21 @@ def test_parse_single_file_should_use_filename_as_skill_name_when_not_in_frontma
     skill = parse_single_file(skill_file, Skill)
 
     assert skill.name == "my-skill"
+
+
+def test_parse_single_file_should_use_parent_directory_name_for_skill_md(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "deploy-tool"
+    skill_dir.mkdir()
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+
+    skill = parse_single_file(skill_file, Skill)
+
+    assert skill.name == "deploy-tool"
+    assert skill.description == "Deploys the app"
+    assert skill.prompt == "Deploy it"
 
 
 def test_parse_single_file_should_use_explicit_name_in_frontmatter(
@@ -483,6 +705,93 @@ def test_load_directory_config_should_load_skills_from_charlie_skills_directory(
     assert len(config.skills) == 1
     assert config.skills[0].name == "explain-code"
     assert config.skills[0].description == "Explains code"
+
+
+def test_load_directory_config_should_load_directory_based_skill_with_extra_files(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".charlie" / "skills" / "deploy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+    (skill_dir / "deploy.sh").write_text("#!/bin/bash\necho deploy")
+
+    config = load_directory_config(tmp_path)
+
+    assert len(config.skills) == 1
+    assert config.skills[0].name == "deploy"
+    assert config.skills[0].description == "Deploys the app"
+    assert "deploy.sh" in config.skills[0].files
+    assert config.skills[0].files["deploy.sh"] == str(skill_dir / "deploy.sh")
+
+
+def test_load_directory_config_should_collect_nested_extra_files(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".charlie" / "skills" / "deploy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+    templates = skill_dir / "templates"
+    templates.mkdir()
+    (templates / "config.yaml").write_text("key: value")
+
+    config = load_directory_config(tmp_path)
+
+    assert len(config.skills) == 1
+    files = config.skills[0].files
+    assert "templates/config.yaml" in files
+
+
+def test_load_directory_config_should_not_include_skill_md_in_extra_files(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".charlie" / "skills" / "deploy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+    (skill_dir / "helper.sh").write_text("#!/bin/bash")
+
+    config = load_directory_config(tmp_path)
+
+    files = config.skills[0].files
+    assert "SKILL.md" not in files
+    assert "helper.sh" in files
+
+
+def test_load_directory_config_should_have_empty_files_for_flat_skills(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".charlie" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "explain-code.md").write_text("---\ndescription: Explains code\n---\nExplain the code")
+
+    config = load_directory_config(tmp_path)
+
+    assert config.skills[0].files == {}
+
+
+def test_load_directory_config_should_load_mixed_flat_and_directory_skills(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / ".charlie" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "explain-code.md").write_text("---\ndescription: Explains code\n---\nExplain the code")
+
+    deploy_dir = skills_dir / "deploy"
+    deploy_dir.mkdir()
+    (deploy_dir / "SKILL.md").write_text("---\ndescription: Deploys the app\n---\nDeploy it")
+    (deploy_dir / "deploy.sh").write_text("#!/bin/bash\necho deploy")
+
+    config = load_directory_config(tmp_path)
+
+    assert len(config.skills) == 2
+    names = [s.name for s in config.skills]
+    assert "explain-code" in names
+    assert "deploy" in names
+
+    deploy_skill = next(s for s in config.skills if s.name == "deploy")
+    assert "deploy.sh" in deploy_skill.files
+
+    explain_skill = next(s for s in config.skills if s.name == "explain-code")
+    assert explain_skill.files == {}
 
 
 # ─── Schema validation ────────────────────────────────────────────────────────
@@ -605,3 +914,24 @@ def test_placeholder_transformer_should_preserve_skill_name_and_description() ->
 
     assert result.name == "my-skill"
     assert result.description == "My fixed description"
+
+
+def test_placeholder_transformer_should_preserve_skill_files() -> None:
+    project = Project(name="my-project", namespace=None, dir=".")
+    transformer = PlaceholderTransformer(
+        placeholders={"agent_name": "Claude Code"},
+        variables={},
+        project=project,
+    )
+    files = {"helper.sh": "/path/to/helper.sh", "templates/config.yaml": "/path/to/config.yaml"}
+    skill = Skill(
+        name="my-skill",
+        description="My skill",
+        prompt="Use {{agent_name}}",
+        files=files,
+    )
+
+    result = transformer.skill(skill)
+
+    assert result.files == files
+    assert result.prompt == "Use Claude Code"


### PR DESCRIPTION
Skills can now be defined as directories (.charlie/skills/<name>/SKILL.md) in addition to the existing flat-file format (.charlie/skills/<name>.md). Extra files placed alongside SKILL.md in the directory are automatically copied to the target agent's skill output directory, enabling skills to bundle templates, scripts, or other resources.

Changes:
- Add `files` field to the Skill schema for tracking companion files
- Update config reader to discover directory-based skills and collect their extra files, deriving the skill name from the directory name
- Update Claude and Cursor configurators to copy companion files alongside the generated SKILL.md
- Pass through the files field in PlaceholderTransformer
- Add comprehensive tests and a directory-based skill example

Assisted-by: Cursor (claude-4.6-opus-high-thinking)