### PR TITLE
Add directory-based skills and generate Claude commands as skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Charlie is a universal agent configuration generator that produces agent-specific commands, MCP configurations, and rules from a single YAML/Markdown spec.
 
-[![Tests](https://img.shields.io/badge/tests-94%20passed-green)]()
-[![Coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-350%20passed-green)]()
+[![Coverage](https://img.shields.io/badge/coverage-84%25-brightgreen)]()
 [![Python](https://img.shields.io/badge/python-3.11+-blue)]()
 
 ## Features
@@ -226,8 +226,12 @@ project/
     │   ├── code-reviewer.md      # One file per subagent (Markdown with YAML frontmatter)
     │   └── debugger.md
     ├── skills/
-    │   ├── explain-code.md       # One file per skill (Markdown with YAML frontmatter)
-    │   └── deploy.md
+    │   ├── explain-code.md       # Flat file skill (Markdown with YAML frontmatter)
+    │   └── deploy/               # Directory-based skill
+    │       ├── SKILL.md          # Skill definition (required)
+    │       ├── deploy.sh         # Companion files (copied to output)
+    │       └── templates/
+    │           └── config.yaml
     └── mcp-servers/
         └── local-tools.yaml      # MCP servers in YAML
 ```
@@ -268,9 +272,9 @@ Charlie supports these universal placeholders in commands, rules, and MCP config
 
 **Agent Path Placeholders:**
 
-- `{{commands_dir}}` → Resolves to agent's commands directory (e.g., `.claude/commands/`)
+- `{{commands_dir}}` → Resolves to agent's commands directory (e.g., `.claude/skills`, `.cursor/commands`)
 - `{{rules_dir}}` → Resolves to agent's rules directory (e.g., `.claude/rules/`)
-- `{{rules_file}}` → Resolves to agent's rules file path (e.g., `.claude/rules.md`)
+- `{{rules_file}}` → Resolves to agent's rules file path (e.g., `CLAUDE.md`, `.cursor/rules`)
 - `{{subagents_dir}}` → Resolves to agent's subagents directory (e.g., `.claude/agents`)
 - `{{skills_dir}}` → Resolves to agent's skills directory (e.g., `.claude/skills`)
 - `{{mcp_file}}` → Resolves to agent's MCP configuration file name (e.g., `mcp.json`)
@@ -510,6 +514,8 @@ Charlie currently supports the following AI agents:
 
 Run `charlie list-agents` to see all available agents.
 
+> **Note:** Claude Code has [merged custom commands into skills](https://code.claude.com/docs/en/skills). Charlie generates Claude commands as `.claude/skills/{name}/SKILL.md` (the same format as skills). For Cursor, commands are still generated as `.cursor/commands/{name}.md`.
+
 ### Metadata support
 
 Charlie uses **pass-through metadata** - add any agent-specific metadata to your commands or rules, and Charlie will include them in generated output:
@@ -594,7 +600,9 @@ Skills are portable, version-controlled packages that teach agents how to perfor
 
 ### Define skills
 
-**Directory-based** — create `.charlie/skills/<name>.md`:
+Charlie supports three ways to define skills:
+
+**Flat file** — create `.charlie/skills/<name>.md`:
 
 ```markdown
 ---
@@ -610,6 +618,32 @@ When explaining code, always include:
 ```
 
 The filename becomes the skill name (e.g., `explain-code.md` → `explain-code`). Override it with a `name:` field in the frontmatter.
+
+**Directory-based** — create `.charlie/skills/<name>/SKILL.md`:
+
+```
+.charlie/skills/deploy/
+├── SKILL.md              # Skill definition (required)
+├── deploy.sh             # Companion files (copied to output)
+└── templates/
+    └── config.yaml
+```
+
+```markdown
+---
+description: Deploy the application to production
+disable-model-invocation: true
+---
+
+Deploy the application:
+
+1. Run the test suite
+2. Build using the template at `{{skills_dir}}/deploy/templates/config.yaml`
+3. Execute `{{skills_dir}}/deploy/deploy.sh`
+4. Verify the deployment succeeded
+```
+
+The directory name becomes the skill name (e.g., `deploy/` → `deploy`). Any files alongside `SKILL.md` are automatically copied to the output skill directory, preserving the relative path structure. This lets skills bundle scripts, templates, or reference material that the agent can access at runtime.
 
 **YAML inline** — add a `skills:` section to `charlie.yaml`:
 
@@ -630,15 +664,17 @@ skills:
       disable-model-invocation: true
 ```
 
+Both flat and directory-based skills can coexist in the same `.charlie/skills/` folder.
+
 ### Generated output
 
-| Agent          | Output                                  | Supported metadata                                                                              |
-| -------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Claude Code    | `.claude/skills/{name}/SKILL.md`        | `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent` |
-| Cursor         | `.cursor/skills/{name}/SKILL.md`        | `description`, `disable-model-invocation`, `license`, `compatibility`                          |
-| GitHub Copilot | — (skipped)                             | —                                                                                               |
+| Agent          | Output                           | Supported metadata                                                                                                                  |
+| -------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code    | `.claude/skills/{name}/SKILL.md` | `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks` |
+| Cursor         | `.cursor/skills/{name}/SKILL.md` | `description`, `disable-model-invocation`, `license`, `compatibility`                                                               |
+| GitHub Copilot | — (skipped)                      | —                                                                                                                                   |
 
-Each skill is output as a directory containing a `SKILL.md` file, following the [Agent Skills](https://agentskills.io) open standard.
+Each skill is output as a directory containing a `SKILL.md` file, following the [Agent Skills](https://agentskills.io) open standard. Companion files from directory-based skills are copied alongside `SKILL.md` in the output.
 
 ### Namespace support
 

--- a/examples/simple/.claude/skills/init/SKILL.md
+++ b/examples/simple/.claude/skills/init/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: init
 description: Initialize a new feature
 ---
 

--- a/examples/simple/.claude/skills/plan/SKILL.md
+++ b/examples/simple/.claude/skills/plan/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: plan
 description: Create implementation plan
 ---
 

--- a/src/charlie/configurators/claude_configurator.py
+++ b/src/charlie/configurators/claude_configurator.py
@@ -14,8 +14,6 @@ from charlie.tracker import Tracker
 
 @final
 class ClaudeConfigurator(AgentConfigurator):
-    COMMANDS_DIR = ".claude/commands"
-    COMMANDS_EXTENSION = "md"
     COMMANDS_SHORTHAND_INJECTION = "$ARGUMENTS"
     RULES_FILE = "CLAUDE.md"
     RULES_DIR = ".claude/rules"
@@ -28,7 +26,6 @@ class ClaudeConfigurator(AgentConfigurator):
     SETTINGS_FILE = ".claude/settings.local.json"
     ASSETS_DIR = ".claude/assets"
 
-    __ALLOWED_COMMAND_METADATA = ["description", "allowed-tools", "argument-hint", "model", "disable-model-invocation"]
     __ALLOWED_INSTRUCTION_METADATA = ["description"]
     __ALLOWED_SUBAGENT_METADATA = [
         "tools",
@@ -52,6 +49,7 @@ class ClaudeConfigurator(AgentConfigurator):
         "model",
         "context",
         "agent",
+        "hooks",
     ]
 
     def __init__(
@@ -75,7 +73,7 @@ class ClaudeConfigurator(AgentConfigurator):
             "agent_name": "Claude Code",
             "agent_shortname": self.short_name,
             "agent_dir": ".claude",
-            "commands_dir": self.COMMANDS_DIR,
+            "commands_dir": self.SKILLS_DIR,
             "commands_shorthand_injection": self.COMMANDS_SHORTHAND_INJECTION,
             "rules_dir": self.RULES_DIR,
             "rules_file": self.RULES_FILE,
@@ -86,23 +84,13 @@ class ClaudeConfigurator(AgentConfigurator):
         }
 
     def commands(self, commands: list[Command]) -> None:
-        commands_dir = Path(self.project.dir) / self.COMMANDS_DIR
-        commands_dir.mkdir(parents=True, exist_ok=True)
         for command in commands:
-            name = command.name
-            filename = f"{name}.{self.COMMANDS_EXTENSION}"
-            if self.project.namespace is not None:
-                filename = f"{self.project.namespace}-{filename}"
-
-            command_file = commands_dir / filename
-            self.markdown_generator.generate(
-                file=command_file,
-                body=command.prompt,
-                metadata={"description": command.description, **command.metadata},
-                allowed_metadata=self.__ALLOWED_COMMAND_METADATA,
+            self.__write_skill(
+                name=command.name,
+                description=command.description,
+                prompt=command.prompt,
+                metadata=command.metadata,
             )
-
-            self.tracker.track(f"Created {command_file}")
 
     def rules(self, rules: list[Rule], mode: RuleMode) -> None:
         if not rules:
@@ -173,35 +161,47 @@ class ClaudeConfigurator(AgentConfigurator):
             self.tracker.track(f"Created {subagent_file}")
 
     def skills(self, skills: list[Skill]) -> None:
-        if not skills:
-            return
+        for skill in skills:
+            self.__write_skill(
+                name=skill.name,
+                description=skill.description,
+                prompt=skill.prompt,
+                metadata=skill.metadata,
+                files=skill.files,
+            )
 
+    def __write_skill(
+        self,
+        name: str,
+        description: str,
+        prompt: str,
+        metadata: dict[str, Any],
+        files: dict[str, str] | None = None,
+    ) -> None:
         skills_dir = Path(self.project.dir) / self.SKILLS_DIR
         skills_dir.mkdir(parents=True, exist_ok=True)
 
-        for skill in skills:
-            name = skill.name
-            if self.project.namespace is not None:
-                name = f"{self.project.namespace}-{name}"
+        if self.project.namespace is not None:
+            name = f"{self.project.namespace}-{name}"
 
-            skill_dir = skills_dir / name
-            skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
 
-            skill_file = skill_dir / self.SKILLS_FILE
-            self.markdown_generator.generate(
-                file=skill_file,
-                body=skill.prompt,
-                metadata={**skill.metadata, "name": name, "description": skill.description},
-                allowed_metadata=["name", *self.__ALLOWED_SKILL_METADATA],
-            )
+        skill_file = skill_dir / self.SKILLS_FILE
+        self.markdown_generator.generate(
+            file=skill_file,
+            body=prompt,
+            metadata={**metadata, "name": name, "description": description},
+            allowed_metadata=["name", *self.__ALLOWED_SKILL_METADATA],
+        )
 
-            self.tracker.track(f"Created {skill_file}")
+        self.tracker.track(f"Created {skill_file}")
 
-            for relative_path, source_path in skill.files.items():
-                dest = skill_dir / relative_path
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(source_path, dest)
-                self.tracker.track(f"Created {dest}")
+        for relative_path, source_path in (files or {}).items():
+            dest = skill_dir / relative_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, dest)
+            self.tracker.track(f"Created {dest}")
 
     def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
         if not mcp_servers:

--- a/tests/test_claude_configurator.py
+++ b/tests/test_claude_configurator.py
@@ -53,19 +53,19 @@ def configurator(
     return ClaudeConfigurator(project, tracker, markdown_generator, mcp_server_generator, assets_manager, "claude")
 
 
-def test_should_create_commands_directory_when_it_does_not_exist(
+def test_should_create_skills_directory_when_generating_commands(
     configurator: ClaudeConfigurator, project: Project
 ) -> None:
     commands = [Command(name="test", description="Test command", prompt="Test prompt")]
 
     configurator.commands(commands)
 
-    commands_dir = Path(project.dir) / ".claude/commands"
-    assert commands_dir.exists()
-    assert commands_dir.is_dir()
+    skills_dir = Path(project.dir) / ".claude/skills"
+    assert skills_dir.exists()
+    assert skills_dir.is_dir()
 
 
-def test_should_create_markdown_file_when_processing_each_command(
+def test_should_create_skill_file_when_processing_each_command(
     configurator: ClaudeConfigurator, project: Project
 ) -> None:
     commands = [
@@ -75,8 +75,8 @@ def test_should_create_markdown_file_when_processing_each_command(
 
     configurator.commands(commands)
 
-    fix_file = Path(project.dir) / ".claude/commands/fix-issue.md"
-    review_file = Path(project.dir) / ".claude/commands/review-pr.md"
+    fix_file = Path(project.dir) / ".claude/skills/fix-issue/SKILL.md"
+    review_file = Path(project.dir) / ".claude/skills/review-pr/SKILL.md"
 
     assert fix_file.exists()
     assert review_file.exists()
@@ -89,7 +89,7 @@ def test_should_write_prompt_to_file_body_when_creating_command(
 
     configurator.commands(commands)
 
-    file = Path(project.dir) / ".claude/commands/test.md"
+    file = Path(project.dir) / ".claude/skills/test/SKILL.md"
     content = file.read_text()
 
     assert "Fix issue #$ARGUMENTS following our coding standards" in content
@@ -102,7 +102,7 @@ def test_should_include_description_in_frontmatter_when_creating_command(
 
     configurator.commands(commands)
 
-    file = Path(project.dir) / ".claude/commands/test.md"
+    file = Path(project.dir) / ".claude/skills/test/SKILL.md"
     content = file.read_text()
 
     assert "description: Fix a numbered issue" in content
@@ -122,7 +122,7 @@ def test_should_include_allowed_tools_in_frontmatter_when_specified(
 
     configurator.commands(commands)
 
-    file = Path(project.dir) / ".claude/commands/test.md"
+    file = Path(project.dir) / ".claude/skills/test/SKILL.md"
     content = file.read_text()
 
     assert "allowed-tools: Bash(git add:*), Bash(git status:*)" in content
@@ -142,13 +142,13 @@ def test_should_include_argument_hint_in_frontmatter_when_specified(
 
     configurator.commands(commands)
 
-    file = Path(project.dir) / ".claude/commands/test.md"
+    file = Path(project.dir) / ".claude/skills/test/SKILL.md"
     content = file.read_text()
 
     assert "argument-hint: '[pr-number] [priority]'" in content
 
 
-def test_should_apply_namespace_prefix_to_filename_when_namespace_is_present(
+def test_should_apply_namespace_prefix_to_directory_when_namespace_is_present(
     project_with_namespace: Project,
     tracker: Mock,
     markdown_generator: MarkdownGenerator,
@@ -167,7 +167,7 @@ def test_should_apply_namespace_prefix_to_filename_when_namespace_is_present(
 
     configurator.commands(commands)
 
-    file = Path(project_with_namespace.dir) / ".claude/commands/myapp-test.md"
+    file = Path(project_with_namespace.dir) / ".claude/skills/myapp-test/SKILL.md"
     assert file.exists()
 
 
@@ -183,8 +183,8 @@ def test_should_track_each_file_when_creating_commands(
 
     assert tracker.track.call_count == 2
     tracked_files = [call[0][0] for call in tracker.track.call_args_list]
-    assert any("fix-issue.md" in str(f) for f in tracked_files)
-    assert any("review-pr.md" in str(f) for f in tracked_files)
+    assert any("fix-issue" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
+    assert any("review-pr" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
 
 
 def test_should_filter_custom_metadata_when_not_in_allowed_list(
@@ -201,7 +201,7 @@ def test_should_filter_custom_metadata_when_not_in_allowed_list(
 
     configurator.commands(commands)
 
-    file = Path(project.dir) / ".claude/commands/test.md"
+    file = Path(project.dir) / ".claude/skills/test/SKILL.md"
     content = file.read_text()
 
     assert "forbidden_field" not in content


### PR DESCRIPTION
Skills can now be defined as directories (.charlie/skills/<name>/SKILL.md) in addition to flat files (.charlie/skills/<name>.md). Companion files placed alongside SKILL.md are automatically copied to the agent's output skill directory, enabling skills to bundle scripts, templates, or reference material.

Claude Code commands are now generated as skills under .claude/skills/ instead of .claude/commands/, matching Claude's upstream merge of custom commands into the skills system. A shared __write_skill() method in the Claude configurator eliminates duplication between commands() and skills().

Other changes:
- Add `files` field to the Skill schema for companion file tracking
- Add `hooks` to Claude's allowed skill metadata per official docs
- Normalize skill file paths with as_posix() for Windows compatibility
- Update README to reflect new skill formats, Claude command behavior, placeholder resolution, and corrected badge counts

Assisted-by: Cursor (claude-4.6-opus-high-thinking)