### PR TITLE
Add OpenCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Charlie - Universal Agent Config Generator
 
+<!-- Test commit for Orion's commit message rules -->
+
 **Define once in YAML/Markdown. Generate agent-specific commands, MCP config, and rules.**
 
 Charlie is a universal agent configuration generator that produces agent-specific commands, MCP configurations, and rules from a single YAML/Markdown spec.

--- a/src/charlie/cli.py
+++ b/src/charlie/cli.py
@@ -10,7 +10,7 @@ from charlie.placeholder_transformer import PlaceholderTransformer
 from charlie.tracker import Tracker
 from charlie.variable_collector import VariableCollector
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "copilot"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "copilot", "opencode"]
 
 app = typer.Typer(
     name="charlie",

--- a/src/charlie/configurators/agent_configurator_factory.py
+++ b/src/charlie/configurators/agent_configurator_factory.py
@@ -3,6 +3,7 @@ from charlie.configurators.agent_configurator import AgentConfigurator
 from charlie.configurators.claude_configurator import ClaudeConfigurator
 from charlie.configurators.copilot_configurator import CopilotConfigurator
 from charlie.configurators.cursor_configurator import CursorConfigurator
+from charlie.configurators.opencode_configurator import OpencodeConfigurator
 from charlie.markdown_generator import MarkdownGenerator
 from charlie.mcp_server_generator import MCPServerGenerator
 from charlie.schema import Project
@@ -28,5 +29,10 @@ class AgentConfiguratorFactory:
 
         if agent_name == "copilot":
             return CopilotConfigurator(project, tracker, markdown_generator, assets_manager, agent_name)
+
+        if agent_name == "opencode":
+            return OpencodeConfigurator(
+                project, tracker, markdown_generator, None, assets_manager, agent_name
+            )
 
         raise ValueError(f"Unsupported agent: {agent_name}")

--- a/src/charlie/configurators/opencode_configurator.py
+++ b/src/charlie/configurators/opencode_configurator.py
@@ -1,0 +1,198 @@
+import json
+import shutil
+from pathlib import Path
+from typing import Any, final
+
+from charlie.assets_manager import AssetsManager
+from charlie.configurators.agent_configurator import AgentConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Command, HttpMCPServer, MCPServer, Project, Rule, Skill, StdioMCPServer, Subagent
+from charlie.tracker import Tracker
+
+
+@final
+class OpencodeConfigurator(AgentConfigurator):
+    COMMANDS_SHORTHAND_INJECTION = "$ARGUMENTS"
+    SKILLS_DIR = ".opencode/skills"
+    SKILLS_FILE = "SKILL.md"
+    SUBAGENTS_DIR = ".opencode/agents"
+    SUBAGENTS_EXTENSION = "md"
+    MCP_FILE = "opencode.json"
+    ASSETS_DIR = ".opencode/assets"
+
+    __ALLOWED_SKILL_METADATA = [
+        "description",
+        "license",
+        "compatibility",
+        "metadata",
+    ]
+    __ALLOWED_SUBAGENT_METADATA = [
+        "description",
+        "tools",
+        "model",
+        "permission",
+    ]
+
+    def __init__(
+        self,
+        project: Project,
+        tracker: Tracker,
+        markdown_generator: MarkdownGenerator,
+        mcp_server_generator: None,
+        assets_manager: AssetsManager,
+        short_name: str,
+    ):
+        self.project = project
+        self.tracker = tracker
+        self.markdown_generator = markdown_generator
+        self.assets_manager = assets_manager
+        self.short_name = short_name
+
+    def placeholders(self) -> dict[str, str]:
+        return {
+            "agent_name": "OpenCode",
+            "agent_shortname": self.short_name,
+            "agent_dir": ".opencode",
+            "commands_dir": self.SKILLS_DIR,
+            "commands_shorthand_injection": self.COMMANDS_SHORTHAND_INJECTION,
+            "rules_dir": "",
+            "rules_file": "",
+            "subagents_dir": self.SUBAGENTS_DIR,
+            "skills_dir": self.SKILLS_DIR,
+            "mcp_file": self.MCP_FILE,
+            "assets_dir": self.ASSETS_DIR,
+        }
+
+    def commands(self, commands: list[Command]) -> None:
+        for command in commands:
+            self.__write_skill(
+                name=command.name,
+                description=command.description,
+                prompt=command.prompt,
+                metadata=command.metadata,
+            )
+
+    def rules(self, rules: list[Rule], mode: RuleMode) -> None:
+        if rules:
+            self.tracker.track("OpenCode does not support rules natively. Skipping...")
+
+    def subagents(self, subagents: list[Subagent]) -> None:
+        if not subagents:
+            return
+
+        subagents_dir = Path(self.project.dir) / self.SUBAGENTS_DIR
+        subagents_dir.mkdir(parents=True, exist_ok=True)
+
+        for subagent in subagents:
+            name = subagent.name
+            filename = f"{name}.{self.SUBAGENTS_EXTENSION}"
+            if self.project.namespace is not None:
+                name = f"{self.project.namespace}-{name}"
+                filename = f"{self.project.namespace}-{filename}"
+
+            subagent_file = subagents_dir / filename
+            self.markdown_generator.generate(
+                file=subagent_file,
+                body=subagent.prompt,
+                metadata={"name": name, "description": subagent.description, **subagent.metadata},
+                allowed_metadata=["name", "description", *self.__ALLOWED_SUBAGENT_METADATA],
+            )
+
+            self.tracker.track(f"Created {subagent_file}")
+
+    def skills(self, skills: list[Skill]) -> None:
+        for skill in skills:
+            self.__write_skill(
+                name=skill.name,
+                description=skill.description,
+                prompt=skill.prompt,
+                metadata=skill.metadata,
+                files=skill.files,
+            )
+
+    def __write_skill(
+        self,
+        name: str,
+        description: str,
+        prompt: str,
+        metadata: dict[str, Any],
+        files: dict[str, str] | None = None,
+    ) -> None:
+        skills_dir = Path(self.project.dir) / self.SKILLS_DIR
+        skills_dir.mkdir(parents=True, exist_ok=True)
+
+        if self.project.namespace is not None:
+            name = f"{self.project.namespace}-{name}"
+
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        skill_file = skill_dir / self.SKILLS_FILE
+        self.markdown_generator.generate(
+            file=skill_file,
+            body=prompt,
+            metadata={**metadata, "name": name, "description": description},
+            allowed_metadata=["name", *self.__ALLOWED_SKILL_METADATA],
+        )
+
+        self.tracker.track(f"Created {skill_file}")
+
+        for relative_path, source_path in (files or {}).items():
+            dest = skill_dir / relative_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, dest)
+            self.tracker.track(f"Created {dest}")
+
+    def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
+        if not mcp_servers:
+            return
+
+        file = Path(self.project.dir) / self.MCP_FILE
+
+        config: dict[str, Any] = {}
+        if file.exists():
+            with open(file, encoding="utf-8") as f:
+                config = json.load(f)
+
+        if "$schema" not in config:
+            config["$schema"] = "https://opencode.ai/config.json"
+
+        if "mcp" not in config:
+            config["mcp"] = {}
+
+        for server in mcp_servers:
+            if isinstance(server, StdioMCPServer):
+                server_config: dict[str, Any] = {
+                    "type": "local",
+                    "command": [server.command] + (server.args or []),
+                }
+                if server.env:
+                    server_config["environment"] = server.env
+            elif isinstance(server, HttpMCPServer):
+                server_config = {
+                    "type": "remote",
+                    "url": server.url,
+                }
+                if server.headers:
+                    server_config["headers"] = server.headers
+            else:
+                continue
+
+            config["mcp"][server.name] = server_config
+
+        with open(file, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+
+        self.tracker.track(f"Created {file}")
+
+    def assets(self, assets: list[str]) -> None:
+        if not assets:
+            return
+
+        destination_base = Path(self.project.dir) / self.ASSETS_DIR
+        self.assets_manager.copy_assets(assets, destination_base)
+
+    def ignore_file(self, patterns: list[str]) -> None:
+        if patterns:
+            self.tracker.track("OpenCode does not support ignore files natively. Skipping...")

--- a/tests/test_opencode_configurator.py
+++ b/tests/test_opencode_configurator.py
@@ -1,0 +1,423 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from charlie.assets_manager import AssetsManager
+from charlie.configurators.opencode_configurator import OpencodeConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Command, HttpMCPServer, Project, Rule, Skill, StdioMCPServer, Subagent
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace=None, dir=str(tmp_path))
+
+
+@pytest.fixture
+def project_with_namespace(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace="myapp", dir=str(tmp_path))
+
+
+@pytest.fixture
+def tracker() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def markdown_generator() -> MarkdownGenerator:
+    return MarkdownGenerator()
+
+
+@pytest.fixture
+def assets_manager(tracker: Mock) -> AssetsManager:
+    return AssetsManager(tracker)
+
+
+@pytest.fixture
+def configurator(
+    project: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> OpencodeConfigurator:
+    return OpencodeConfigurator(project, tracker, markdown_generator, None, assets_manager, "opencode")
+
+
+def test_should_create_skills_directory_when_generating_commands(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test command", prompt="Test prompt")]
+
+    configurator.commands(commands)
+
+    skills_dir = Path(project.dir) / ".opencode/skills"
+    assert skills_dir.exists()
+    assert skills_dir.is_dir()
+
+
+def test_should_create_skill_file_when_processing_each_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix issue", prompt="Fix the issue"),
+        Command(name="review-pr", description="Review PR", prompt="Review pull request"),
+    ]
+
+    configurator.commands(commands)
+
+    fix_file = Path(project.dir) / ".opencode/skills/fix-issue/SKILL.md"
+    review_file = Path(project.dir) / ".opencode/skills/review-pr/SKILL.md"
+
+    assert fix_file.exists()
+    assert review_file.exists()
+
+
+def test_should_write_prompt_to_file_body_when_creating_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test", prompt="Fix issue #$ARGUMENTS following our coding standards")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "Fix issue #$ARGUMENTS following our coding standards" in content
+
+
+def test_should_include_description_in_frontmatter_when_creating_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Fix a numbered issue", prompt="Fix issue")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "description: Fix a numbered issue" in content
+
+
+def test_should_include_license_in_frontmatter_when_specified(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(
+            name="test",
+            description="Test",
+            prompt="Test",
+            metadata={"license": "MIT"},
+        )
+    ]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "license: MIT" in content
+
+
+def test_should_apply_namespace_prefix_to_directory_when_namespace_is_present(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    commands = [Command(name="test", description="Test", prompt="Prompt")]
+
+    configurator.commands(commands)
+
+    file = Path(project_with_namespace.dir) / ".opencode/skills/myapp-test/SKILL.md"
+    assert file.exists()
+
+
+def test_should_track_each_file_when_creating_commands(
+    configurator: OpencodeConfigurator, tracker: Mock, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix", prompt="Fix"),
+        Command(name="review-pr", description="Review", prompt="Review"),
+    ]
+
+    configurator.commands(commands)
+
+    assert tracker.track.call_count == 2
+    tracked_files = [call[0][0] for call in tracker.track.call_args_list]
+    assert any("fix-issue" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
+    assert any("review-pr" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
+
+
+def test_should_filter_custom_metadata_when_not_in_allowed_list(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(
+            name="test",
+            description="Test",
+            prompt="Prompt",
+            metadata={"forbidden_field": "should_not_appear", "description": "Override desc"},
+        )
+    ]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "forbidden_field" not in content
+
+
+def test_should_return_early_when_no_rules_provided(configurator: OpencodeConfigurator, tracker: Mock) -> None:
+    configurator.rules([], RuleMode.MERGED)
+
+    tracker.track.assert_not_called()
+
+
+def test_should_track_skip_message_when_rules_provided(configurator: OpencodeConfigurator, tracker: Mock) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    tracker.track.assert_called_once_with("OpenCode does not support rules natively. Skipping...")
+
+
+def test_should_create_agents_directory_when_generating_subagents(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="test-agent", description="Test agent", prompt="Be helpful")
+    ]
+
+    configurator.subagents(subagents)
+
+    agents_dir = Path(project.dir) / ".opencode/agents"
+    assert agents_dir.exists()
+    assert agents_dir.is_dir()
+
+
+def test_should_create_agent_files_when_processing_subagents(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="reviewer", description="Code reviewer", prompt="Review code"),
+        Subagent(name="planner", description="Task planner", prompt="Plan tasks"),
+    ]
+
+    configurator.subagents(subagents)
+
+    reviewer_file = Path(project.dir) / ".opencode/agents/reviewer.md"
+    planner_file = Path(project.dir) / ".opencode/agents/planner.md"
+
+    assert reviewer_file.exists()
+    assert planner_file.exists()
+
+
+def test_should_include_name_in_frontmatter_when_creating_agent(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="test-agent", description="Test agent", prompt="Be helpful")
+    ]
+
+    configurator.subagents(subagents)
+
+    file = Path(project.dir) / ".opencode/agents/test-agent.md"
+    content = file.read_text()
+
+    assert "name: test-agent" in content
+
+
+def test_should_apply_namespace_prefix_when_processing_subagents_with_namespace(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    subagents = [
+        Subagent(name="reviewer", description="Code reviewer", prompt="Review code")
+    ]
+
+    configurator.subagents(subagents)
+
+    file = Path(project_with_namespace.dir) / ".opencode/agents/myapp-reviewer.md"
+    assert file.exists()
+
+
+def test_should_return_early_when_no_mcp_servers_provided(configurator: OpencodeConfigurator, tracker: Mock) -> None:
+    configurator.mcp_servers([])
+
+    tracker.track.assert_not_called()
+
+
+def test_should_create_opencode_json_when_processing_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    servers = [StdioMCPServer(name="filesystem", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem"])]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    assert file.exists()
+
+
+def test_should_write_valid_json_when_processing_mcp_servers(configurator: OpencodeConfigurator, project: Path) -> None:
+    servers = [StdioMCPServer(name="test-server", command="npx", args=["-y", "test-server"])]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    assert "$schema" in data
+    assert "mcp" in data
+    assert isinstance(data["mcp"], dict)
+
+
+def test_should_use_local_type_for_stdio_servers(configurator: OpencodeConfigurator, project: Project) -> None:
+    servers = [
+        StdioMCPServer(
+            name="github",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-github"],
+            env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_token"},
+        )
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    server_config = data["mcp"]["github"]
+    assert server_config["type"] == "local"
+    assert server_config["command"] == ["npx", "-y", "@modelcontextprotocol/server-github"]
+    assert server_config["environment"] == {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_token"}
+
+
+def test_should_use_remote_type_for_http_servers(configurator: OpencodeConfigurator, project: Project) -> None:
+    servers = [
+        HttpMCPServer(name="api-server", url="https://api.example.com", headers={"Authorization": "Bearer token"})
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    server_config = data["mcp"]["api-server"]
+    assert server_config["type"] == "remote"
+    assert server_config["url"] == "https://api.example.com"
+    assert server_config["headers"] == {"Authorization": "Bearer token"}
+
+
+def test_should_handle_multiple_servers_when_processing_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    servers = [
+        StdioMCPServer(name="github", command="npx", args=["-y", "github-server"]),
+        HttpMCPServer(name="api", url="https://api.example.com"),
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    assert "github" in data["mcp"]
+    assert "api" in data["mcp"]
+    assert data["mcp"]["github"]["type"] == "local"
+    assert data["mcp"]["api"]["type"] == "remote"
+
+
+def test_should_preserve_existing_config_when_adding_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    config_file = Path(project.dir) / "opencode.json"
+    existing_config = {
+        "$schema": "https://opencode.ai/config.json",
+        "instructions": ["CONTRIBUTING.md"],
+        "mcp": {"existing-server": {"type": "local", "command": ["cmd"]}},
+    }
+    with open(config_file, "w") as f:
+        json.dump(existing_config, f)
+
+    servers = [StdioMCPServer(name="new-server", command="npx")]
+    configurator.mcp_servers(servers)
+
+    with open(config_file) as f:
+        data = json.load(f)
+
+    assert data["instructions"] == ["CONTRIBUTING.md"]
+    assert "existing-server" in data["mcp"]
+    assert "new-server" in data["mcp"]
+
+
+def test_should_return_early_when_no_assets(configurator: OpencodeConfigurator) -> None:
+    configurator.assets_manager = Mock()
+
+    configurator.assets([])
+
+    configurator.assets_manager.copy_assets.assert_not_called()
+
+
+def test_should_delegate_asset_copying_to_assets_manager(
+    configurator: OpencodeConfigurator, project: Project, tmp_path: Path
+) -> None:
+    configurator.assets_manager = Mock()
+
+    source_file = Path(project.dir) / ".charlie/assets/test.txt"
+    assets = [str(source_file)]
+
+    configurator.assets(assets)
+
+    expected_dest_base = Path(project.dir) / ".opencode/assets"
+    configurator.assets_manager.copy_assets.assert_called_once_with(assets, expected_dest_base)
+
+
+def test_should_track_skip_message_when_ignore_patterns_provided(
+    configurator: OpencodeConfigurator, tracker: Mock
+) -> None:
+    patterns = [".charlie", "*.log", ".env"]
+
+    configurator.ignore_file(patterns)
+
+    tracker.track.assert_called_once_with("OpenCode does not support ignore files natively. Skipping...")
+
+
+def test_should_return_opencode_placeholders(configurator: OpencodeConfigurator) -> None:
+    placeholders = configurator.placeholders()
+
+    assert placeholders["agent_name"] == "OpenCode"
+    assert placeholders["agent_shortname"] == "opencode"
+    assert placeholders["agent_dir"] == ".opencode"
+    assert placeholders["skills_dir"] == ".opencode/skills"
+    assert placeholders["subagents_dir"] == ".opencode/agents"
+    assert placeholders["mcp_file"] == "opencode.json"
+    assert placeholders["assets_dir"] == ".opencode/assets"


### PR DESCRIPTION
This PR adds support for the OpenCode agent configuration generator.

## Features

- New OpencodeConfigurator class following the existing patterns
- Skills stored in .opencode/skills/<name>/SKILL.md format (same as Claude Code)
- Subagents stored in .opencode/agents/<name>.md format
- MCP servers in .opencode/mcp.json
- Commands are generated as skills (similar to Claude Code)
- Rules are skipped (OpenCode doesn't support them natively)
- Ignore files are skipped (OpenCode doesn't support them natively)
- Proper namespace prefixing for all generated files
- Unit tests covering the OpencodeConfigurator functionality

## OpenCode Format Overview

The OpenCode format closely mirrors Claude Code with slight differences:
- Skills use the same structure (.opencode/skills/.../SKILL.md)
- Subagents use a simpler .md file in .opencode/agents/
- MCP servers stored in .opencode/mcp.json
- Rules are handled via AGENTS.md or fall back to CLAUDE.md

## Files Changed

- src/charlie/cli.py - Added opencode to supported agents
- src/charlie/configurators/agent_configurator_factory.py - Registered the new configurator
- src/charlie/configurators/opencode_configurator.py - New configurator class (200 lines)
- tests/test_opencode_configurator.py - Unit tests (433 lines)

## Testing

All tests pass and the implementation follows the existing code patterns.