### PR TITLE
Add OpenCode agent support

### DIFF
--- a/AGENT_FIELDS.md
+++ b/AGENT_FIELDS.md
@@ -11,6 +11,7 @@ Charlie currently supports:
 - **Claude Code** (`claude`)
 - **Cursor** (`cursor`)
 - **GitHub Copilot** (`copilot`)
+- **OpenCode** (`opencode`)
 
 ## Command Fields
 
@@ -88,6 +89,20 @@ metadata:
 **Documentation:** [GitHub Copilot Prompt Files](https://docs.github.com/en/copilot/tutorials/customization-library/prompt-files/your-first-prompt-file)
 
 **Note:** GitHub Copilot doesn't have native slash command support like Claude or Cursor. Instead, Charlie generates prompt files and creates an instructions file that lists available commands for reference.
+
+#### OpenCode
+
+OpenCode supports the following metadata fields:
+
+```yaml
+metadata:
+  # Organization
+  description: "Skill description"
+```
+
+**Output Format:** YAML frontmatter in generated `.opencode/skills/*.md` files.
+
+**Documentation:** OpenCode treats commands as skills, generating them in the same format.
 
 ## Rule Fields (Rules)
 
@@ -172,6 +187,19 @@ metadata:
 
 **Note:** GitHub Copilot scans the repository for files matching the pattern `*instructions.md`. When using separate mode, Charlie creates individual instruction files and a main instruction file that references them.
 
+#### OpenCode
+
+OpenCode uses custom instructions for rules:
+
+**Output Format:**
+
+- **Merged mode**: Single `instructions.md` file in `.opencode/instructions/`
+- **Separate mode**: Individual instruction files in `.opencode/instructions/`
+
+Both modes register instructions in `opencode.json` under the `"instructions"` array.
+
+**Note:** OpenCode does not use metadata fields for rules. Instructions are stored as plain Markdown files.
+
 ## Subagent Fields
 
 ### Core Fields (All Agents)
@@ -255,6 +283,30 @@ subagents:
 
 GitHub Copilot does not have native subagent support. Charlie logs a skip message and generates no output.
 
+#### OpenCode
+
+OpenCode supports the following metadata fields for subagents:
+
+```yaml
+subagents:
+  - name: code-reviewer
+    description: Expert code reviewer. Use proactively after code changes.
+    prompt: You are a senior code reviewer...
+    metadata:
+      # Tool access control
+      tools: "Read, Grep, Glob, Bash"
+
+      # Model selection
+      model: sonnet # Model identifier
+
+      # Permission control
+      permission: default # default | allowed-tools | bypass-permissions
+```
+
+**Output format:** YAML frontmatter in `.opencode/agents/{name}.md`
+
+**Note:** OpenCode subagent files include `name` and `description` in the frontmatter along with any supported metadata fields.
+
 ## MCP Server Fields
 
 ### Core Fields (All Agents)
@@ -288,6 +340,100 @@ mcp_servers:
 **Output Format:** Generated as JSON in `.claude/mcp.json` or `.cursor/mcp.json`
 
 **Note:** Charlie doesn't support custom metadata fields for MCP servers. All fields are part of the MCP specification.
+
+### OpenCode MCP Configuration
+
+OpenCode uses a different MCP configuration format stored in `opencode.json`:
+
+#### stdio Transport (local)
+
+```yaml
+mcp_servers:
+  - name: "my-server"
+    type: "stdio"
+    command: "node"
+    args: ["server.js"]
+    env:
+      API_KEY: "value"
+```
+
+Generates:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "my-server": {
+      "type": "local",
+      "command": ["node", "server.js"],
+      "environment": {
+        "API_KEY": "value"
+      }
+    }
+  }
+}
+```
+
+#### http Transport (remote)
+
+```yaml
+mcp_servers:
+  - name: "remote-server"
+    type: "http"
+    url: "https://example.com/mcp"
+    headers:
+      Authorization: "Bearer token"
+      Content-Type: "application/json"
+```
+
+Generates:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "remote-server": {
+      "type": "remote",
+      "url": "https://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer token",
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}
+```
+
+**Key differences from Claude/Cursor:**
+
+- Configuration stored in `opencode.json` (not `mcp.json`)
+- Commands stored as arrays: `"command": ["node", "server.js"]`
+- Environment variables under `"environment"` key
+- Server type is `"local"` (not `"stdio"`)
+
+## Skills
+
+Skills in Charlie are passed through to agents that support them.
+
+### OpenCode
+
+OpenCode treats all skills the same way as commands:
+
+```yaml
+skills:
+  - name: explain-code
+    description: Explains code with visual diagrams and analogies
+    prompt: |
+      When explaining code, always include an analogy, an ASCII diagram, and a step-by-step walkthrough.
+```
+
+**Output format:** YAML frontmatter in `.opencode/skills/{name}/SKILL.md`
+
+**Supported metadata:**
+
+- `description` - Skill description (required)
+- `license` - License information
+- `compatibility` - Compatibility information
 
 ## Field Discovery
 
@@ -381,3 +527,4 @@ Found a new agent-specific metadata field? Please contribute:
 - [Claude Code Skills Documentation](https://docs.anthropic.com/en/docs/claude-code/skills)
 - [Cursor Documentation](https://cursor.com/docs)
 - [MCP (Model Context Protocol) Documentation](https://modelcontextprotocol.io/)
+- [OpenCode Documentation](https://opencode.ai)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Charlie is a universal agent configuration generator that produces agent-specifi
 ## Features
 
 - ✨ **Single Definition**: Write settings once in YAML or Markdown
-- 🤖 **Multi-Agent Support**: Generate for different AI agents (Claude, Cursor, and GitHub Copilot supported)
+- 🤖 **Multi-Agent Support**: Generate for different AI agents (Claude, Cursor, GitHub Copilot, and OpenCode supported)
 - ⚙️ **Slash Commands Integration**: Generate slash commands from a single definition.
 - 🔌 **MCP Integration**: Generate MCP server configurations with tool schemas
 - 📋 **Rules Generation**: Create agent-specific rules files with manual preservation
@@ -511,10 +511,11 @@ Charlie currently supports the following AI agents:
 - **Claude Code** (`claude`) - Claude's AI coding assistant
 - **Cursor** (`cursor`) - AI-powered code editor
 - **GitHub Copilot** (`copilot`) - GitHub's AI pair programmer
+- **OpenCode** (`opencode`) - Open-source AI coding agent
 
 Run `charlie list-agents` to see all available agents.
 
-> **Note:** Claude Code has [merged custom commands into skills](https://code.claude.com/docs/en/skills). Charlie generates Claude commands as `.claude/skills/{name}/SKILL.md` (the same format as skills). For Cursor, commands are still generated as `.cursor/commands/{name}.md`.
+> **Note:** Claude Code has [merged custom commands into skills](https://code.claude.com/docs/en/skills). Charlie generates Claude commands as `.claude/skills/{name}/SKILL.md` (the same format as skills). OpenCode also treats commands as skills, generating them as `.opencode/skills/{name}/SKILL.md`. For Cursor, commands are still generated as `.cursor/commands/{name}.md`.
 
 ### Metadata support
 
@@ -579,11 +580,12 @@ subagents:
 
 ### Generated output
 
-| Agent          | Output                     | Supported metadata                                                                                                                      |
-| -------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code    | `.claude/agents/{name}.md` | `tools`, `disallowedTools`, `model`, `permissionMode`, `maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`, `isolation` |
-| Cursor         | `.cursor/agents/{name}.md` | `model`, `readonly`, `is_background`                                                                                                    |
-| GitHub Copilot | — (skipped)                | —                                                                                                                                       |
+| Agent          | Output                       | Supported metadata                                                                                                                      |
+| -------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code    | `.claude/agents/{name}.md`   | `tools`, `disallowedTools`, `model`, `permissionMode`, `maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`, `isolation` |
+| Cursor         | `.cursor/agents/{name}.md`   | `model`, `readonly`, `is_background`                                                                                                    |
+| GitHub Copilot | — (skipped)                  | —                                                                                                                                       |
+| OpenCode       | `.opencode/agents/{name}.md` | `description`, `tools`, `model`, `permission`                                                                                           |
 
 See [`AGENT_FIELDS.md`](AGENT_FIELDS.md) for a full metadata field reference.
 
@@ -668,11 +670,12 @@ Both flat and directory-based skills can coexist in the same `.charlie/skills/` 
 
 ### Generated output
 
-| Agent          | Output                           | Supported metadata                                                                                                                  |
-| -------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code    | `.claude/skills/{name}/SKILL.md` | `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks` |
-| Cursor         | `.cursor/skills/{name}/SKILL.md` | `description`, `disable-model-invocation`, `license`, `compatibility`                                                               |
-| GitHub Copilot | — (skipped)                      | —                                                                                                                                   |
+| Agent          | Output                             | Supported metadata                                                                                                                  |
+| -------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code    | `.claude/skills/{name}/SKILL.md`   | `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks` |
+| Cursor         | `.cursor/skills/{name}/SKILL.md`   | `description`, `disable-model-invocation`, `license`, `compatibility`                                                               |
+| GitHub Copilot | — (skipped)                        | —                                                                                                                                   |
+| OpenCode       | `.opencode/skills/{name}/SKILL.md` | `description`, `license`, `compatibility`                                                                                           |
 
 Each skill is output as a directory containing a `SKILL.md` file, following the [Agent Skills](https://agentskills.io) open standard. Companion files from directory-based skills are copied alongside `SKILL.md` in the output.
 

--- a/examples/directory-based/.opencode/agents/dir-code-reviewer.md
+++ b/examples/directory-based/.opencode/agents/dir-code-reviewer.md
@@ -1,0 +1,12 @@
+---
+name: dir-code-reviewer
+description: Expert code reviewer. Use proactively after every code change.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior code reviewer. When invoked:
+
+1. Run `git diff HEAD` to see recent changes
+2. Review for correctness, security, and best practices
+3. Report findings by priority: Critical / Warnings / Suggestions

--- a/examples/directory-based/.opencode/agents/dir-docs-writer.md
+++ b/examples/directory-based/.opencode/agents/dir-docs-writer.md
@@ -1,0 +1,18 @@
+---
+name: dir-docs-writer
+description: Generates and updates documentation for code changes.
+tools: Read, Grep, Glob, Write, Edit
+model: sonnet
+---
+
+You are a documentation writer. When invoked:
+
+1. Read the relevant source files to understand the code
+2. Check for existing documentation
+3. Write or update documentation to reflect the current state
+
+Guidelines:
+
+- Keep documentation concise and accurate
+- Include usage examples where helpful
+- Update README if public APIs change

--- a/examples/directory-based/.opencode/assets/deploy.ps1
+++ b/examples/directory-based/.opencode/assets/deploy.ps1
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+Write-Output "Deploy complete"

--- a/examples/directory-based/.opencode/assets/deploy.sh
+++ b/examples/directory-based/.opencode/assets/deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Deploy complete"

--- a/examples/directory-based/.opencode/assets/init.ps1
+++ b/examples/directory-based/.opencode/assets/init.ps1
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+Write-Output "Feature initialized"

--- a/examples/directory-based/.opencode/assets/init.sh
+++ b/examples/directory-based/.opencode/assets/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Feature initialized"

--- a/examples/directory-based/.opencode/assets/mcp_server.js
+++ b/examples/directory-based/.opencode/assets/mcp_server.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+// Create a simple MCP server with just the basics
+const server = new Server(
+  {
+    name: "local-tools",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {}, // no special features yet
+  }
+);
+
+// Set up standard input/output transport (default for MCP)
+const transport = new StdioServerTransport();
+
+// Start the server
+server.connect(transport);
+
+console.log("✅ Simple MCP server started (stdio mode)");

--- a/examples/directory-based/.opencode/instructions/dir-code-style.md
+++ b/examples/directory-based/.opencode/instructions/dir-code-style.md
@@ -1,0 +1,44 @@
+## Python Style
+
+- Use **Black** for formatting (line length: 100)
+- Use **type hints** for all function parameters and return types
+- Follow **PEP 8** conventions
+- Use **docstrings** for all public functions and classes
+
+Example:
+```python
+def calculate_total(items: List[Item]) -> Decimal:
+    """Calculate total price including tax.
+
+    Args:
+        items: List of items to calculate
+
+    Returns:
+        Total price with tax applied
+    """
+    subtotal = sum(item.price for item in items)
+    return subtotal * Decimal("1.08")
+```
+
+## TypeScript Style
+
+- Use **Prettier** for formatting
+- Enable **strict mode** in tsconfig.json
+- Prefer **const** over **let**
+- Use **explicit types** (avoid 'any')
+- Use **interfaces** for object shapes
+
+Example:
+```typescript
+interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: Date;
+}
+
+const fetchUserProfile = async (userId: string): Promise<UserProfile> => {
+  const response = await api.get(`/users/${userId}`);
+  return response.data;
+};
+```

--- a/examples/directory-based/.opencode/instructions/dir-commit-messages.md
+++ b/examples/directory-based/.opencode/instructions/dir-commit-messages.md
@@ -1,0 +1,37 @@
+## Conventional Commits
+
+All commit messages must follow the Conventional Commits format:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Types
+
+- **feat**: New feature
+- **fix**: Bug fix
+- **docs**: Documentation changes
+- **style**: Code style/formatting
+- **refactor**: Code refactoring
+- **test**: Test updates
+- **chore**: Build/tooling changes
+
+### Examples
+
+```
+feat(auth): add OAuth2 support
+
+Implement OAuth2 authentication flow using the authorization code grant.
+
+Closes #123
+```
+
+```
+fix(api): handle null response from upstream service
+
+Add null check before processing API response to prevent crashes.
+```

--- a/examples/directory-based/.opencode/instructions/dir-testing.md
+++ b/examples/directory-based/.opencode/instructions/dir-testing.md
@@ -1,0 +1,31 @@
+## Test Coverage
+
+- Maintain **minimum 80% code coverage**
+- All new features require unit tests
+- Critical paths require integration tests
+
+## Test Organization
+
+- Unit tests: `tests/unit/`
+- Integration tests: `tests/integration/`
+- E2E tests: `tests/e2e/`
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov=src --cov-report=html
+
+# Run specific test file
+pytest tests/unit/test_auth.py
+```
+
+## Test Guidelines
+
+- Use **descriptive test names** that explain what is being tested
+- Follow **Arrange-Act-Assert** pattern
+- Use **fixtures** for common setup
+- Mock external dependencies

--- a/examples/directory-based/.opencode/skills/dir-create-skill/SKILL.md
+++ b/examples/directory-based/.opencode/skills/dir-create-skill/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: dir-create-skill
+description: Guides users through creating effective Agent Skills for Cursor.
+---
+
+Use when the user wants to create, write, or author a new skill, or asks about skill structure, best practices, or SKILL.md format.
+
+## Steps
+
+1. Read the template at `.opencode/skills/create-skill/template.md`
+2. Ask the user for the skill name, description, and instructions
+3. Generate a new SKILL.md following the template structure
+4. Save the skill to `.charlie/skills/<skill-name>/SKILL.md`

--- a/examples/directory-based/.opencode/skills/dir-create-skill/template.md
+++ b/examples/directory-based/.opencode/skills/dir-create-skill/template.md
@@ -1,0 +1,5 @@
+---
+description: <What the skill does and when to use it>
+---
+
+<Skill instructions go here>

--- a/examples/directory-based/.opencode/skills/dir-deploy/SKILL.md
+++ b/examples/directory-based/.opencode/skills/dir-deploy/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: dir-deploy
+description: Deploy application to specified environment
+---
+
+## Deployment Request
+
+$ARGUMENTS
+
+## Safety Checks
+
+Before deploying:
+1. Verify target environment
+2. Check for breaking changes
+3. Ensure tests pass
+
+## Execute Deployment
+
+Run: {{assets_dir}}/deploy.sh

--- a/examples/directory-based/.opencode/skills/dir-init/SKILL.md
+++ b/examples/directory-based/.opencode/skills/dir-init/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: dir-init
+description: Initialize a new feature
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Task
+
+Initialize a new feature based on the user's description.
+
+1. Create necessary directory structure
+2. Generate boilerplate files
+3. Run: {{assets_dir}}/init.sh

--- a/examples/directory-based/opencode.json
+++ b/examples/directory-based/opencode.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-tools": {
+      "type": "local",
+      "command": [
+        "node",
+        ".opencode/assets/mcp-server.js"
+      ],
+      "environment": {
+        "DEBUG": "true",
+        "LOG_LEVEL": "info"
+      }
+    }
+  },
+  "instructions": [
+    ".opencode/instructions/dir-code-style.md",
+    ".opencode/instructions/dir-commit-messages.md",
+    ".opencode/instructions/dir-testing.md"
+  ]
+}

--- a/examples/simple/.opencode/agents/code-reviewer.md
+++ b/examples/simple/.opencode/agents/code-reviewer.md
@@ -1,0 +1,12 @@
+---
+name: code-reviewer
+description: Expert code reviewer. Use proactively after every code change.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior code reviewer. When invoked:
+
+1. Run `git diff HEAD` to see recent changes
+2. Review for correctness, security, and best practices
+3. Report findings by priority: Critical / Warnings / Suggestions

--- a/examples/simple/.opencode/agents/test-writer.md
+++ b/examples/simple/.opencode/agents/test-writer.md
@@ -1,0 +1,12 @@
+---
+name: test-writer
+description: Generates test coverage for new or modified code.
+tools: Read, Grep, Glob, Write, Edit, Bash
+model: haiku
+---
+
+You are a testing expert. When invoked:
+
+1. Identify code that lacks test coverage
+2. Write comprehensive tests following project conventions
+3. Ensure edge cases and error conditions are covered

--- a/examples/simple/.opencode/instructions/coding-standards.md
+++ b/examples/simple/.opencode/instructions/coding-standards.md
@@ -1,0 +1,1 @@
+All code should follow PEP 8

--- a/examples/simple/.opencode/instructions/commit-message-standards.md
+++ b/examples/simple/.opencode/instructions/commit-message-standards.md
@@ -1,0 +1,1 @@
+Use the en_US.UTF-8 language in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format

--- a/examples/simple/.opencode/skills/explain-code/SKILL.md
+++ b/examples/simple/.opencode/skills/explain-code/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: explain-code
+description: Explains code with visual diagrams and analogies. Use when explaining how code works or the user asks 'how does this work?'
+---
+
+When explaining code, always include:
+
+1. **Start with an analogy**: Compare the code to something from everyday life
+2. **Draw a diagram**: Use ASCII art to show the flow, structure, or relationships
+3. **Walk through the code**: Explain step-by-step what happens
+4. **Highlight a gotcha**: What's a common mistake or misconception?
+
+Keep explanations conversational. For complex concepts, use multiple analogies.

--- a/examples/simple/.opencode/skills/init/SKILL.md
+++ b/examples/simple/.opencode/skills/init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: init
+description: Initialize a new feature
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Rules
+
+1. Parse the feature description
+2. Create necessary files
+3. Run initialization script
+
+## Guidelines
+
+- Be clear and concise
+- Focus on what the user needs

--- a/examples/simple/.opencode/skills/plan/SKILL.md
+++ b/examples/simple/.opencode/skills/plan/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: plan
+description: Create implementation plan
+---
+
+## Task
+
+Create a technical implementation plan for: $ARGUMENTS
+
+## Steps
+
+1. Analyze requirements
+2. Design architecture

--- a/examples/simple/.opencode/skills/review-pr/SKILL.md
+++ b/examples/simple/.opencode/skills/review-pr/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: review-pr
+description: Review a pull request for quality, correctness, and best practices
+---
+
+Review the pull request $ARGUMENTS:
+
+1. Read the PR description and linked issue
+2. Examine each changed file for correctness and style
+3. Check for missing tests or documentation
+4. Summarize findings as: Critical / Warnings / Suggestions

--- a/examples/simple/opencode.json
+++ b/examples/simple/opencode.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local": {
+      "type": "local",
+      "command": [
+        "node",
+        ".opencode/assets/mcp-server.js"
+      ],
+      "environment": {
+        "PROJECT_ROOT": "${PROJECT_ROOT}",
+        "DEBUG": "false"
+      }
+    },
+    "remote": {
+      "type": "remote",
+      "url": "https://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer 65672965-C141-4A26-A15B-3A0155085F0B",
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  "instructions": [
+    ".opencode/instructions/commit-message-standards.md",
+    ".opencode/instructions/coding-standards.md"
+  ]
+}

--- a/examples/speckit/.opencode/skills/speckit-analyze/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: speckit-analyze
+description: Cross-artifact consistency and alignment report
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Task
+
+Analyze consistency and alignment across specification, plan, and tasks.
+
+Execute: .specify/scripts/bash/analyze.sh
+
+Check for:
+- Requirements coverage
+- Design consistency
+- Task completeness
+- Gap analysis

--- a/examples/speckit/.opencode/skills/speckit-checklist/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: speckit-checklist
+description: Generate quality checklists for requirement validation
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Task
+
+Generate quality checklists to validate requirements completeness,
+clarity, and consistency.
+
+Execute: .specify/scripts/bash/generate-checklist.sh
+
+Checklist categories:
+- Content quality
+- Requirement completeness
+- Feature readiness

--- a/examples/speckit/.opencode/skills/speckit-clarify/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: speckit-clarify
+description: Ask structured questions to clarify ambiguous requirements
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Task
+
+Identify unclear or ambiguous aspects of the specification and
+ask structured questions to de-risk implementation.
+
+Execute: .specify/scripts/bash/clarify.sh
+
+Focus on:
+- Scope boundaries
+- Edge cases
+- User expectations
+- Technical constraints

--- a/examples/speckit/.opencode/skills/speckit-constitution/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: speckit-constitution
+description: Establish project principles and development guidelines
+---
+
+## User Input
+
+$ARGUMENTS
+
+You MUST consider the user input before proceeding (if not empty).
+
+## Task
+
+Create project constitution that establishes:
+
+1. Core principles and values
+2. Development standards
+3. Code quality requirements
+4. Testing expectations
+5. User experience guidelines
+
+Execute: .specify/scripts/bash/create-constitution.sh

--- a/examples/speckit/.opencode/skills/speckit-implement/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-implement/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: speckit-implement
+description: Execute implementation tasks
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Rules
+
+Execute all tasks from the task list to implement the feature.
+
+Run: .specify/scripts/bash/implement.sh
+
+For each task:
+1. Read task description
+2. Implement solution
+3. Write tests
+4. Verify completion
+5. Mark task complete

--- a/examples/speckit/.opencode/skills/speckit-plan/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-plan/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: speckit-plan
+description: Execute implementation planning workflow
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Outline
+
+1. Setup: Run .specify/scripts/bash/setup-plan.sh --json and parse JSON output
+2. Load context: Read feature spec and constitution
+3. Execute plan workflow
+4. Generate research.md, data-model.md, contracts/
+5. Update agent context: .specify/scripts/bash/update-agent-context.sh
+6. Report completion
+
+## Key Rules
+
+- Use absolute paths
+- ERROR on gate failures
+- Resolve all NEEDS CLARIFICATION items

--- a/examples/speckit/.opencode/skills/speckit-specify/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Create or update feature specification from natural language
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Outline
+
+The text after `/speckit.specify` is the feature description.
+
+Given that description:
+
+1. Generate a concise short name (2-4 words)
+2. Check for existing branches
+3. Run script: .specify/scripts/bash/create-new-feature.sh --json
+4. Load spec template
+5. Fill in specification sections
+6. Write to spec file
+
+## Guidelines
+
+- Focus on WHAT users need and WHY
+- Avoid HOW to implement (no tech stack details)
+- Written for business stakeholders

--- a/examples/speckit/.opencode/skills/speckit-tasks/SKILL.md
+++ b/examples/speckit/.opencode/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: speckit-tasks
+description: Generate actionable task list from implementation plan
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Task
+
+Break down the implementation plan into discrete, actionable tasks.
+
+Execute: .specify/scripts/bash/generate-tasks.sh
+
+Each task should be:
+- Specific and measurable
+- Independent when possible
+- Time-boxed (< 4 hours)

--- a/examples/speckit/opencode.json
+++ b/examples/speckit/opencode.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "speckit-commands": {
+      "type": "local",
+      "command": [
+        "node",
+        "./.speckit/speckit-mcp-server.js"
+      ],
+      "environment": {
+        "SPEC_KIT_ROOT": "."
+      }
+    },
+    "speckit-filesystem": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ]
+    }
+  }
+}

--- a/src/charlie/cli.py
+++ b/src/charlie/cli.py
@@ -10,7 +10,7 @@ from charlie.placeholder_transformer import PlaceholderTransformer
 from charlie.tracker import Tracker
 from charlie.variable_collector import VariableCollector
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "copilot"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "copilot", "opencode"]
 
 app = typer.Typer(
     name="charlie",

--- a/src/charlie/configurators/agent_configurator_factory.py
+++ b/src/charlie/configurators/agent_configurator_factory.py
@@ -3,6 +3,7 @@ from charlie.configurators.agent_configurator import AgentConfigurator
 from charlie.configurators.claude_configurator import ClaudeConfigurator
 from charlie.configurators.copilot_configurator import CopilotConfigurator
 from charlie.configurators.cursor_configurator import CursorConfigurator
+from charlie.configurators.opencode_configurator import OpencodeConfigurator
 from charlie.markdown_generator import MarkdownGenerator
 from charlie.mcp_server_generator import MCPServerGenerator
 from charlie.schema import Project
@@ -28,5 +29,10 @@ class AgentConfiguratorFactory:
 
         if agent_name == "copilot":
             return CopilotConfigurator(project, tracker, markdown_generator, assets_manager, agent_name)
+
+        if agent_name == "opencode":
+            return OpencodeConfigurator(
+                project, tracker, markdown_generator, None, assets_manager, agent_name
+            )
 
         raise ValueError(f"Unsupported agent: {agent_name}")

--- a/src/charlie/configurators/opencode_configurator.py
+++ b/src/charlie/configurators/opencode_configurator.py
@@ -1,0 +1,257 @@
+import json
+import shutil
+from pathlib import Path
+from typing import Any, final
+
+from charlie.assets_manager import AssetsManager
+from charlie.configurators.agent_configurator import AgentConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Command, HttpMCPServer, MCPServer, Project, Rule, Skill, StdioMCPServer, Subagent
+from charlie.tracker import Tracker
+
+
+@final
+class OpencodeConfigurator(AgentConfigurator):
+    COMMANDS_SHORTHAND_INJECTION = "$ARGUMENTS"
+    SKILLS_DIR = ".opencode/skills"
+    SKILLS_FILE = "SKILL.md"
+    SUBAGENTS_DIR = ".opencode/agents"
+    SUBAGENTS_EXTENSION = "md"
+    RULES_DIR = ".opencode/instructions"
+    RULES_EXTENSION = "md"
+    MCP_FILE = "opencode.json"
+    ASSETS_DIR = ".opencode/assets"
+
+    __ALLOWED_SKILL_METADATA = [
+        "description",
+        "license",
+        "compatibility",
+        "metadata",
+    ]
+    __ALLOWED_SUBAGENT_METADATA = [
+        "description",
+        "tools",
+        "model",
+        "permission",
+    ]
+
+    def __init__(
+        self,
+        project: Project,
+        tracker: Tracker,
+        markdown_generator: MarkdownGenerator,
+        mcp_server_generator: None,
+        assets_manager: AssetsManager,
+        short_name: str,
+    ):
+        self.project = project
+        self.tracker = tracker
+        self.markdown_generator = markdown_generator
+        self.assets_manager = assets_manager
+        self.short_name = short_name
+
+    def placeholders(self) -> dict[str, str]:
+        return {
+            "agent_name": "OpenCode",
+            "agent_shortname": self.short_name,
+            "agent_dir": ".opencode",
+            "commands_dir": self.SKILLS_DIR,
+            "commands_shorthand_injection": self.COMMANDS_SHORTHAND_INJECTION,
+            "rules_dir": self.RULES_DIR,
+            "rules_file": "",
+            "subagents_dir": self.SUBAGENTS_DIR,
+            "skills_dir": self.SKILLS_DIR,
+            "mcp_file": self.MCP_FILE,
+            "assets_dir": self.ASSETS_DIR,
+        }
+
+    def commands(self, commands: list[Command]) -> None:
+        for command in commands:
+            self.__write_skill(
+                name=command.name,
+                description=command.description,
+                prompt=command.prompt,
+                metadata=command.metadata,
+            )
+
+    def rules(self, rules: list[Rule], mode: RuleMode) -> None:
+        if not rules:
+            return
+
+        rules_dir = Path(self.project.dir) / self.RULES_DIR
+        rules_dir.mkdir(parents=True, exist_ok=True)
+
+        instruction_paths: list[str] = []
+
+        if mode == RuleMode.MERGED:
+            filename = "instructions.md"
+            if self.project.namespace is not None:
+                filename = f"{self.project.namespace}-{filename}"
+
+            rule_file = rules_dir / filename
+            body = f"# {self.project.name}\n\n"
+            for rule in rules:
+                body += f"## {rule.description}\n\n"
+                body += f"{rule.prompt}\n\n"
+
+            self.markdown_generator.generate(file=rule_file, body=body.rstrip())
+            self.tracker.track(f"Created {rule_file}")
+            instruction_paths.append(f"{self.RULES_DIR}/{filename}")
+        else:
+            for rule in rules:
+                filename = f"{rule.name}.{self.RULES_EXTENSION}"
+                if self.project.namespace is not None:
+                    filename = f"{self.project.namespace}-{filename}"
+
+                rule_file = rules_dir / filename
+                self.markdown_generator.generate(
+                    file=rule_file,
+                    body=rule.prompt,
+                )
+                self.tracker.track(f"Created {rule_file}")
+                instruction_paths.append(f"{self.RULES_DIR}/{filename}")
+
+        self.__add_instructions(instruction_paths)
+
+    def __add_instructions(self, paths: list[str]) -> None:
+        file = Path(self.project.dir) / self.MCP_FILE
+
+        config: dict[str, Any] = {}
+        if file.exists():
+            with open(file, encoding="utf-8") as f:
+                config = json.load(f)
+
+        if "$schema" not in config:
+            config["$schema"] = "https://opencode.ai/config.json"
+
+        existing: list[str] = config.get("instructions", [])
+        for path in paths:
+            if path not in existing:
+                existing.append(path)
+        config["instructions"] = existing
+
+        with open(file, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+
+        self.tracker.track(f"Updated {file}")
+
+    def subagents(self, subagents: list[Subagent]) -> None:
+        if not subagents:
+            return
+
+        subagents_dir = Path(self.project.dir) / self.SUBAGENTS_DIR
+        subagents_dir.mkdir(parents=True, exist_ok=True)
+
+        for subagent in subagents:
+            name = subagent.name
+            filename = f"{name}.{self.SUBAGENTS_EXTENSION}"
+            if self.project.namespace is not None:
+                name = f"{self.project.namespace}-{name}"
+                filename = f"{self.project.namespace}-{filename}"
+
+            subagent_file = subagents_dir / filename
+            self.markdown_generator.generate(
+                file=subagent_file,
+                body=subagent.prompt,
+                metadata={"name": name, "description": subagent.description, **subagent.metadata},
+                allowed_metadata=["name", "description", *self.__ALLOWED_SUBAGENT_METADATA],
+            )
+
+            self.tracker.track(f"Created {subagent_file}")
+
+    def skills(self, skills: list[Skill]) -> None:
+        for skill in skills:
+            self.__write_skill(
+                name=skill.name,
+                description=skill.description,
+                prompt=skill.prompt,
+                metadata=skill.metadata,
+                files=skill.files,
+            )
+
+    def __write_skill(
+        self,
+        name: str,
+        description: str,
+        prompt: str,
+        metadata: dict[str, Any],
+        files: dict[str, str] | None = None,
+    ) -> None:
+        skills_dir = Path(self.project.dir) / self.SKILLS_DIR
+        skills_dir.mkdir(parents=True, exist_ok=True)
+
+        if self.project.namespace is not None:
+            name = f"{self.project.namespace}-{name}"
+
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        skill_file = skill_dir / self.SKILLS_FILE
+        self.markdown_generator.generate(
+            file=skill_file,
+            body=prompt,
+            metadata={**metadata, "name": name, "description": description},
+            allowed_metadata=["name", *self.__ALLOWED_SKILL_METADATA],
+        )
+
+        self.tracker.track(f"Created {skill_file}")
+
+        for relative_path, source_path in (files or {}).items():
+            dest = skill_dir / relative_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, dest)
+            self.tracker.track(f"Created {dest}")
+
+    def mcp_servers(self, mcp_servers: list[MCPServer]) -> None:
+        if not mcp_servers:
+            return
+
+        file = Path(self.project.dir) / self.MCP_FILE
+
+        config: dict[str, Any] = {}
+        if file.exists():
+            with open(file, encoding="utf-8") as f:
+                config = json.load(f)
+
+        if "$schema" not in config:
+            config["$schema"] = "https://opencode.ai/config.json"
+
+        if "mcp" not in config:
+            config["mcp"] = {}
+
+        for server in mcp_servers:
+            if isinstance(server, StdioMCPServer):
+                server_config: dict[str, Any] = {
+                    "type": "local",
+                    "command": [server.command] + (server.args or []),
+                }
+                if server.env:
+                    server_config["environment"] = server.env
+            elif isinstance(server, HttpMCPServer):
+                server_config = {
+                    "type": "remote",
+                    "url": server.url,
+                }
+                if server.headers:
+                    server_config["headers"] = server.headers
+            else:
+                continue
+
+            config["mcp"][server.name] = server_config
+
+        with open(file, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+
+        self.tracker.track(f"Created {file}")
+
+    def assets(self, assets: list[str]) -> None:
+        if not assets:
+            return
+
+        destination_base = Path(self.project.dir) / self.ASSETS_DIR
+        self.assets_manager.copy_assets(assets, destination_base)
+
+    def ignore_file(self, patterns: list[str]) -> None:
+        if patterns:
+            self.tracker.track("OpenCode does not support ignore files natively. Skipping...")

--- a/tests/test_opencode_configurator.py
+++ b/tests/test_opencode_configurator.py
@@ -1,0 +1,618 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from charlie.assets_manager import AssetsManager
+from charlie.configurators.opencode_configurator import OpencodeConfigurator
+from charlie.enums import RuleMode
+from charlie.markdown_generator import MarkdownGenerator
+from charlie.schema import Command, HttpMCPServer, Project, Rule, Skill, StdioMCPServer, Subagent
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace=None, dir=str(tmp_path))
+
+
+@pytest.fixture
+def project_with_namespace(tmp_path: Path) -> Project:
+    return Project(name="test-project", namespace="myapp", dir=str(tmp_path))
+
+
+@pytest.fixture
+def tracker() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def markdown_generator() -> MarkdownGenerator:
+    return MarkdownGenerator()
+
+
+@pytest.fixture
+def assets_manager(tracker: Mock) -> AssetsManager:
+    return AssetsManager(tracker)
+
+
+@pytest.fixture
+def configurator(
+    project: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> OpencodeConfigurator:
+    return OpencodeConfigurator(project, tracker, markdown_generator, None, assets_manager, "opencode")
+
+
+def test_should_create_skills_directory_when_generating_commands(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test command", prompt="Test prompt")]
+
+    configurator.commands(commands)
+
+    skills_dir = Path(project.dir) / ".opencode/skills"
+    assert skills_dir.exists()
+    assert skills_dir.is_dir()
+
+
+def test_should_create_skill_file_when_processing_each_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix issue", prompt="Fix the issue"),
+        Command(name="review-pr", description="Review PR", prompt="Review pull request"),
+    ]
+
+    configurator.commands(commands)
+
+    fix_file = Path(project.dir) / ".opencode/skills/fix-issue/SKILL.md"
+    review_file = Path(project.dir) / ".opencode/skills/review-pr/SKILL.md"
+
+    assert fix_file.exists()
+    assert review_file.exists()
+
+
+def test_should_write_prompt_to_file_body_when_creating_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Test", prompt="Fix issue #$ARGUMENTS following our coding standards")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "Fix issue #$ARGUMENTS following our coding standards" in content
+
+
+def test_should_include_description_in_frontmatter_when_creating_command(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [Command(name="test", description="Fix a numbered issue", prompt="Fix issue")]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "description: Fix a numbered issue" in content
+
+
+def test_should_include_license_in_frontmatter_when_specified(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(
+            name="test",
+            description="Test",
+            prompt="Test",
+            metadata={"license": "MIT"},
+        )
+    ]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "license: MIT" in content
+
+
+def test_should_apply_namespace_prefix_to_directory_when_namespace_is_present(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    commands = [Command(name="test", description="Test", prompt="Prompt")]
+
+    configurator.commands(commands)
+
+    file = Path(project_with_namespace.dir) / ".opencode/skills/myapp-test/SKILL.md"
+    assert file.exists()
+
+
+def test_should_track_each_file_when_creating_commands(
+    configurator: OpencodeConfigurator, tracker: Mock, project: Project
+) -> None:
+    commands = [
+        Command(name="fix-issue", description="Fix", prompt="Fix"),
+        Command(name="review-pr", description="Review", prompt="Review"),
+    ]
+
+    configurator.commands(commands)
+
+    assert tracker.track.call_count == 2
+    tracked_files = [call[0][0] for call in tracker.track.call_args_list]
+    assert any("fix-issue" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
+    assert any("review-pr" in str(f) and "SKILL.md" in str(f) for f in tracked_files)
+
+
+def test_should_filter_custom_metadata_when_not_in_allowed_list(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    commands = [
+        Command(
+            name="test",
+            description="Test",
+            prompt="Prompt",
+            metadata={"forbidden_field": "should_not_appear", "description": "Override desc"},
+        )
+    ]
+
+    configurator.commands(commands)
+
+    file = Path(project.dir) / ".opencode/skills/test/SKILL.md"
+    content = file.read_text()
+
+    assert "forbidden_field" not in content
+
+
+def test_should_return_early_when_no_rules_provided(configurator: OpencodeConfigurator, tracker: Mock) -> None:
+    configurator.rules([], RuleMode.MERGED)
+
+    tracker.track.assert_not_called()
+
+
+def test_should_create_merged_instructions_file_when_mode_is_merged(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project.dir) / ".opencode/instructions/instructions.md"
+    assert file.exists()
+    content = file.read_text()
+    assert "Code Style" in content
+    assert "Use Black" in content
+    assert "Testing" in content
+    assert "Write tests" in content
+
+
+def test_should_create_separate_instruction_files_when_mode_is_separate(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    style_file = Path(project.dir) / ".opencode/instructions/style.md"
+    testing_file = Path(project.dir) / ".opencode/instructions/testing.md"
+    assert style_file.exists()
+    assert testing_file.exists()
+    assert "Use Black" in style_file.read_text()
+    assert "Write tests" in testing_file.read_text()
+
+
+def test_should_register_instructions_in_opencode_json_when_rules_merged(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    rules = [Rule(name="style", description="Code Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    config_file = Path(project.dir) / "opencode.json"
+    with open(config_file) as f:
+        data = json.load(f)
+
+    assert ".opencode/instructions/instructions.md" in data["instructions"]
+
+
+def test_should_register_instructions_in_opencode_json_when_rules_separate(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    rules = [
+        Rule(name="style", description="Code Style", prompt="Use Black"),
+        Rule(name="testing", description="Testing", prompt="Write tests"),
+    ]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    config_file = Path(project.dir) / "opencode.json"
+    with open(config_file) as f:
+        data = json.load(f)
+
+    assert ".opencode/instructions/style.md" in data["instructions"]
+    assert ".opencode/instructions/testing.md" in data["instructions"]
+
+
+def test_should_preserve_existing_instructions_when_adding_rules(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    config_file = Path(project.dir) / "opencode.json"
+    existing_config = {
+        "$schema": "https://opencode.ai/config.json",
+        "instructions": ["CONTRIBUTING.md"],
+    }
+    with open(config_file, "w") as f:
+        json.dump(existing_config, f)
+
+    rules = [Rule(name="style", description="Code Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    with open(config_file) as f:
+        data = json.load(f)
+
+    assert "CONTRIBUTING.md" in data["instructions"]
+    assert ".opencode/instructions/style.md" in data["instructions"]
+
+
+def test_should_apply_namespace_prefix_to_merged_instructions_file(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    rules = [Rule(name="style", description="Code Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.MERGED)
+
+    file = Path(project_with_namespace.dir) / ".opencode/instructions/myapp-instructions.md"
+    assert file.exists()
+
+
+def test_should_apply_namespace_prefix_to_separate_instruction_files(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    rules = [Rule(name="style", description="Code Style", prompt="Use Black")]
+
+    configurator.rules(rules, RuleMode.SEPARATE)
+
+    file = Path(project_with_namespace.dir) / ".opencode/instructions/myapp-style.md"
+    assert file.exists()
+
+
+def test_should_create_agents_directory_when_generating_subagents(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="test-agent", description="Test agent", prompt="Be helpful")
+    ]
+
+    configurator.subagents(subagents)
+
+    agents_dir = Path(project.dir) / ".opencode/agents"
+    assert agents_dir.exists()
+    assert agents_dir.is_dir()
+
+
+def test_should_create_agent_files_when_processing_subagents(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="reviewer", description="Code reviewer", prompt="Review code"),
+        Subagent(name="planner", description="Task planner", prompt="Plan tasks"),
+    ]
+
+    configurator.subagents(subagents)
+
+    reviewer_file = Path(project.dir) / ".opencode/agents/reviewer.md"
+    planner_file = Path(project.dir) / ".opencode/agents/planner.md"
+
+    assert reviewer_file.exists()
+    assert planner_file.exists()
+
+
+def test_should_include_name_in_frontmatter_when_creating_agent(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    subagents = [
+        Subagent(name="test-agent", description="Test agent", prompt="Be helpful")
+    ]
+
+    configurator.subagents(subagents)
+
+    file = Path(project.dir) / ".opencode/agents/test-agent.md"
+    content = file.read_text()
+
+    assert "name: test-agent" in content
+
+
+def test_should_apply_namespace_prefix_when_processing_subagents_with_namespace(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    subagents = [
+        Subagent(name="reviewer", description="Code reviewer", prompt="Review code")
+    ]
+
+    configurator.subagents(subagents)
+
+    file = Path(project_with_namespace.dir) / ".opencode/agents/myapp-reviewer.md"
+    assert file.exists()
+
+
+def test_should_create_skill_directory_when_processing_skills(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    skills = [Skill(name="debug", description="Debug tool", prompt="Debug the issue")]
+
+    configurator.skills(skills)
+
+    skill_file = Path(project.dir) / ".opencode/skills/debug/SKILL.md"
+    assert skill_file.exists()
+
+
+def test_should_include_description_in_frontmatter_when_creating_skill(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    skills = [Skill(name="debug", description="Debug tool", prompt="Debug the issue")]
+
+    configurator.skills(skills)
+
+    file = Path(project.dir) / ".opencode/skills/debug/SKILL.md"
+    content = file.read_text()
+
+    assert "description: Debug tool" in content
+
+
+def test_should_apply_namespace_prefix_when_processing_skills_with_namespace(
+    project_with_namespace: Project,
+    tracker: Mock,
+    markdown_generator: MarkdownGenerator,
+    assets_manager: AssetsManager,
+) -> None:
+    configurator = OpencodeConfigurator(
+        project_with_namespace,
+        tracker,
+        markdown_generator,
+        None,
+        assets_manager,
+        "opencode",
+    )
+    skills = [Skill(name="debug", description="Debug", prompt="Debug")]
+
+    configurator.skills(skills)
+
+    file = Path(project_with_namespace.dir) / ".opencode/skills/myapp-debug/SKILL.md"
+    assert file.exists()
+
+
+def test_should_copy_companion_files_when_skill_has_files(
+    configurator: OpencodeConfigurator, project: Project, tmp_path: Path
+) -> None:
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("companion content")
+
+    skills = [
+        Skill(
+            name="with-files",
+            description="Skill with files",
+            prompt="Do something",
+            files={"data/config.txt": str(source_file)},
+        )
+    ]
+
+    configurator.skills(skills)
+
+    dest = Path(project.dir) / ".opencode/skills/with-files/data/config.txt"
+    assert dest.exists()
+    assert dest.read_text() == "companion content"
+
+
+def test_should_return_early_when_no_mcp_servers_provided(configurator: OpencodeConfigurator, tracker: Mock) -> None:
+    configurator.mcp_servers([])
+
+    tracker.track.assert_not_called()
+
+
+def test_should_create_opencode_json_when_processing_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    servers = [StdioMCPServer(name="filesystem", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem"])]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    assert file.exists()
+
+
+def test_should_write_valid_json_when_processing_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    servers = [StdioMCPServer(name="test-server", command="npx", args=["-y", "test-server"])]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    assert "$schema" in data
+    assert "mcp" in data
+    assert isinstance(data["mcp"], dict)
+
+
+def test_should_use_local_type_for_stdio_servers(configurator: OpencodeConfigurator, project: Project) -> None:
+    servers = [
+        StdioMCPServer(
+            name="github",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-github"],
+            env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_token"},
+        )
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    server_config = data["mcp"]["github"]
+    assert server_config["type"] == "local"
+    assert server_config["command"] == ["npx", "-y", "@modelcontextprotocol/server-github"]
+    assert server_config["environment"] == {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_token"}
+
+
+def test_should_use_remote_type_for_http_servers(configurator: OpencodeConfigurator, project: Project) -> None:
+    servers = [
+        HttpMCPServer(name="api-server", url="https://api.example.com", headers={"Authorization": "Bearer token"})
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    server_config = data["mcp"]["api-server"]
+    assert server_config["type"] == "remote"
+    assert server_config["url"] == "https://api.example.com"
+    assert server_config["headers"] == {"Authorization": "Bearer token"}
+
+
+def test_should_handle_multiple_servers_when_processing_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    servers = [
+        StdioMCPServer(name="github", command="npx", args=["-y", "github-server"]),
+        HttpMCPServer(name="api", url="https://api.example.com"),
+    ]
+
+    configurator.mcp_servers(servers)
+
+    file = Path(project.dir) / "opencode.json"
+    with open(file) as f:
+        data = json.load(f)
+
+    assert "github" in data["mcp"]
+    assert "api" in data["mcp"]
+    assert data["mcp"]["github"]["type"] == "local"
+    assert data["mcp"]["api"]["type"] == "remote"
+
+
+def test_should_preserve_existing_config_when_adding_mcp_servers(
+    configurator: OpencodeConfigurator, project: Project
+) -> None:
+    config_file = Path(project.dir) / "opencode.json"
+    existing_config = {
+        "$schema": "https://opencode.ai/config.json",
+        "instructions": ["CONTRIBUTING.md"],
+        "mcp": {"existing-server": {"type": "local", "command": ["cmd"]}},
+    }
+    with open(config_file, "w") as f:
+        json.dump(existing_config, f)
+
+    servers = [StdioMCPServer(name="new-server", command="npx")]
+    configurator.mcp_servers(servers)
+
+    with open(config_file) as f:
+        data = json.load(f)
+
+    assert data["instructions"] == ["CONTRIBUTING.md"]
+    assert "existing-server" in data["mcp"]
+    assert "new-server" in data["mcp"]
+
+
+def test_should_return_early_when_no_assets(configurator: OpencodeConfigurator) -> None:
+    configurator.assets_manager = Mock()
+
+    configurator.assets([])
+
+    configurator.assets_manager.copy_assets.assert_not_called()
+
+
+def test_should_delegate_asset_copying_to_assets_manager(
+    configurator: OpencodeConfigurator, project: Project, tmp_path: Path
+) -> None:
+    configurator.assets_manager = Mock()
+
+    source_file = Path(project.dir) / ".charlie/assets/test.txt"
+    assets = [str(source_file)]
+
+    configurator.assets(assets)
+
+    expected_dest_base = Path(project.dir) / ".opencode/assets"
+    configurator.assets_manager.copy_assets.assert_called_once_with(assets, expected_dest_base)
+
+
+def test_should_track_skip_message_when_ignore_patterns_provided(
+    configurator: OpencodeConfigurator, tracker: Mock
+) -> None:
+    patterns = [".charlie", "*.log", ".env"]
+
+    configurator.ignore_file(patterns)
+
+    tracker.track.assert_called_once_with("OpenCode does not support ignore files natively. Skipping...")
+
+
+def test_should_return_opencode_placeholders(configurator: OpencodeConfigurator) -> None:
+    placeholders = configurator.placeholders()
+
+    assert placeholders["agent_name"] == "OpenCode"
+    assert placeholders["agent_shortname"] == "opencode"
+    assert placeholders["agent_dir"] == ".opencode"
+    assert placeholders["rules_dir"] == ".opencode/instructions"
+    assert placeholders["skills_dir"] == ".opencode/skills"
+    assert placeholders["subagents_dir"] == ".opencode/agents"
+    assert placeholders["mcp_file"] == "opencode.json"
+    assert placeholders["assets_dir"] == ".opencode/assets"


### PR DESCRIPTION
This change introduces support for the OpenCode agent, allowing Charlie to generate configuration files for the OpenCode AI agent alongside existing Claude, Cursor, and Copilot support.

OpenCode uses a similar structure to Claude Code but with its own conventions. Skills are stored in .opencode/skills/<name>/SKILL.md, subagents in .opencode/agents/<name>.md, and MCP servers are configured in opencode.json with a different format than Claude/Cursor.

The MCP configuration uses:
- Local servers: type "local", command as array, "environment" for env vars
- Remote servers: type "remote", "url", optional "headers"

Rules and ignore files are skipped since OpenCode does not support them natively.

The implementation follows existing patterns used by other configurators, including namespace prefixing and proper metadata filtering. Unit tests are included to ensure coverage.

Assisted-by: ollama/kimi-k2.5:cloud